### PR TITLE
New tariff processing functionality

### DIFF
--- a/asf_levies_model/getters/load_data.py
+++ b/asf_levies_model/getters/load_data.py
@@ -421,7 +421,7 @@ def _get_raw_dataframe_annex9(data_name: str) -> pd.DataFrame:
     ).reset_index(drop=True)
 
 
-def slice_tariff_components_tables(
+def _slice_tariff_components_tables(
     sheet_start_row: int, levelisation: bool
 ) -> pd.DataFrame:
     """Extracts tariff components tables of interest from Annex 9 tab "1c Consumption adjusted levels".
@@ -457,7 +457,7 @@ def slice_tariff_components_tables(
     return tariff_tables_df
 
 
-def extract_single_tariff_table(
+def _extract_single_tariff_table(
     input_df: pd.DataFrame,
     type_of_consumption: str,
     table_number: int,
@@ -509,7 +509,9 @@ def extract_single_tariff_table(
     return single_tariff_table_df
 
 
-def tidy_tariff_table(input_df: pd.DataFrame, type_of_consumption: str) -> pd.DataFrame:
+def _tidy_tariff_table(
+    input_df: pd.DataFrame, type_of_consumption: str
+) -> pd.DataFrame:
     """Generates a dataframe for tariff components for one fuel type-payment method in tidy format.
 
     Parameters
@@ -537,3 +539,393 @@ def tidy_tariff_table(input_df: pd.DataFrame, type_of_consumption: str) -> pd.Da
     )
 
     return tidy_df
+
+
+def ofgem_archetypes_data() -> pd.DataFrame:
+    """Pre-filled function to generate a dataframe with Ofgem archetype data."""
+    dataframe = pd.concat(
+        [
+            pd.Series(
+                [
+                    "Typical",
+                    "A1",
+                    "A2",
+                    "A3",
+                    "B4",
+                    "B5",
+                    "B6",
+                    "C7",
+                    "C8",
+                    "C9",
+                    "D10",
+                    "D11",
+                    "D12",
+                    "E13",
+                    "E14",
+                    "F15",
+                    "F16",
+                    "G17",
+                    "G18",
+                    "H19",
+                    "H20",
+                    "I21",
+                    "I22",
+                    "J23",
+                    "J24",
+                ],
+                name="AnnualConsumptionProfile",
+            ),
+            pd.Series(
+                [
+                    2700.0,
+                    2742.0,
+                    2849.0,
+                    3519.0,
+                    4811.0,
+                    6597.0,
+                    3028.0,
+                    3649.0,
+                    5587.0,
+                    3337.0,
+                    3881.0,
+                    2482.0,
+                    3952.0,
+                    5075.0,
+                    4070.0,
+                    6883.0,
+                    4317.0,
+                    5901.0,
+                    5294.0,
+                    4907.0,
+                    3143.0,
+                    4070.0,
+                    4684.0,
+                    4532.0,
+                    7523.0,
+                ],
+                name="ElectricitySingleRatekWh",
+            ),
+            pd.Series(
+                [
+                    11500.0,
+                    10933.0,
+                    9464.0,
+                    10622.0,
+                    0.0,
+                    0.0,
+                    10525.0,
+                    13119.0,
+                    0.0,
+                    13685.0,
+                    13981.0,
+                    8782.0,
+                    16065.0,
+                    16722.0,
+                    14606.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    11677.0,
+                    15461.0,
+                    18530.0,
+                    16330.0,
+                    0.0,
+                ],
+                name="GaskWh",
+            ),
+            pd.Series(
+                [
+                    None,
+                    15643,
+                    17327,
+                    18195,
+                    18776,
+                    22423,
+                    24869,
+                    29257,
+                    32240,
+                    32344,
+                    31819,
+                    40980,
+                    38927,
+                    38351,
+                    43026,
+                    46005,
+                    50721,
+                    44586,
+                    49265,
+                    52621,
+                    58924,
+                    59668,
+                    68332,
+                    74795,
+                    78813,
+                ],
+                name="GrossAnnualHouseholdIncome",
+            ),
+            pd.Series(
+                [
+                    "Typical",
+                    "Oldest and poorest",
+                    "Low-income older people in social housing",
+                    "Low-income adults with disability in social housing",
+                    "Old poor people with electric heating",
+                    "Pensioners with medical  equipment and/or electric heating",
+                    "Low-income couples/singles in small rented/social housing",
+                    "Council housing with children",
+                    "Electric council housing with 1 child",
+                    "Pensioners in semi-detached houses",
+                    "Disabled owner-occupiers",
+                    "Flats with good EPC",
+                    "Pensioners in mansions",
+                    "Families with disabilities",
+                    "Average families",
+                    "Mid income large families on other fuel",
+                    "Electric yuppies",
+                    "Welsh barns",
+                    "Other fuels",
+                    "Oil rural older couples",
+                    "High income without children",
+                    "High income families with 1 child",
+                    "Own detached houses with no children",
+                    "High income families with 2+ children",
+                    "Big rich rural homes with children",
+                ],
+                name="ArchetypeNickname",
+            ),
+            pd.Series(
+                [
+                    1_000_000,
+                    578_333,
+                    868_191,
+                    883_413,
+                    731_318,
+                    465_288,
+                    920_172,
+                    659_595,
+                    228_477,
+                    3_408_514,
+                    1_163_946,
+                    1_197_075,
+                    1_457_829,
+                    690_892,
+                    1_178_684,
+                    323_433,
+                    989_639,
+                    163_166,
+                    667_836,
+                    675_712,
+                    3_540_270,
+                    2_210_494,
+                    1_792_593,
+                    1_956_103,
+                    231_658,
+                ],
+                name="ArchetypeSize",
+            ),
+            pd.Series(
+                [
+                    "Gas",  # Typical
+                    "Gas",  # A1
+                    "Gas",  # A2
+                    "Gas",  # A3
+                    "Electricity",  # B4
+                    "Electricity/Other",  # B5
+                    "Gas",  # B6
+                    "Gas",  # C7
+                    "Electricity",  # C8
+                    "Gas",  # C9
+                    "Gas",  # D10
+                    "Gas",  # D11
+                    "Gas",  # D12
+                    "Gas",  # E13
+                    "Gas",  # E14
+                    "Electricity/Other",  # F15
+                    "Electricity",  # F16
+                    "Other",  # G17
+                    "Other",  # G18
+                    "Other",  # H19
+                    "Gas",  # H20
+                    "Gas",  # I21
+                    "Gas",  # I22
+                    "Gas",  # J23
+                    "Other",  # J24
+                ],
+                name="ArchetypeHeatingFuel",
+            ),
+        ],
+        axis=1,
+    )
+    return dataframe
+
+
+def _process_tariff(
+    sheet_start_row: int,
+    levelisation: bool,
+    type_of_consumption: str,
+    table_number: int,
+) -> pd.DataFrame:
+    """Generic function for returning processed tariff component data from annex 9.
+
+    Parameters
+    ----------
+    sheet_start_row : int
+        Row number of header row in target tables in sheet "1c Consumption adjusted levels".
+    levelisation : bool
+        Boolean representing whether "Levelisation" tariff component is included in tariff table of interest.
+    type_of_consumption : str
+        "Nil consumption" or "Typical consumption" ONLY.
+    table_number : int
+       1: Electricity single-rate; 2: Electricity multi-register; 3: Gas; 4: Duel fuel
+    """
+    return _tidy_tariff_table(
+        _extract_single_tariff_table(
+            _slice_tariff_components_tables(sheet_start_row, levelisation),
+            type_of_consumption,
+            table_number,
+        ),
+        type_of_consumption,
+    )
+
+
+## Standard Credit
+# Electricity
+def process_tariff_elec_standard_credit_nil():
+    """Extracts and transforms Standard Credit tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Nil consumption."""
+    sheet_start_row = 55
+    levelisation = False
+    type_of_consumption = "Nil consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_elec_standard_credit_typical():
+    """Extracts and transforms Standard Credit tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Typical consumption."""
+    sheet_start_row = 70
+    levelisation = False
+    type_of_consumption = "Typical consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+# Gas
+def process_tariff_gas_standard_credit_nil():
+    """Extracts and transforms Standard Credit tariff component data from annex 9 for Gas, Nil consumption."""
+    sheet_start_row = 55
+    levelisation = False
+    type_of_consumption = "Nil consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_gas_standard_credit_typical():
+    """Extracts and transforms Standard Credit tariff component data from annex 9 for Gas, Typical consumption."""
+    sheet_start_row = 70
+    levelisation = False
+    type_of_consumption = "Typical consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+## Other payment method
+# Electricity
+def process_tariff_elec_other_payment_nil():
+    """Extracts and transforms Other Payment Method tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Nil consumption."""
+    sheet_start_row = 19
+    levelisation = True
+    type_of_consumption = "Nil consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_elec_other_payment_typical():
+    """Extracts and transforms Other Payment Method tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Typical consumption."""
+    sheet_start_row = 35
+    levelisation = True
+    type_of_consumption = "Typical consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+# Gas
+def process_tariff_gas_other_payment_nil():
+    """Extracts and transforms Other Payment Method tariff component data from annex 9 for Gas, Nil consumption."""
+    sheet_start_row = 19
+    levelisation = True
+    type_of_consumption = "Nil consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_gas_other_payment_typical():
+    """Extracts and transforms Other Payment Method tariff component data from annex 9 for Gas, Typical consumption."""
+    sheet_start_row = 35
+    levelisation = True
+    type_of_consumption = "Typical consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+## PPM
+# Electricity
+def process_tariff_elec_ppm_nil():
+    """Extracts and transforms PPM tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Nil consumption."""
+    sheet_start_row = 88
+    levelisation = True
+    type_of_consumption = "Nil consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_elec_ppm_typical():
+    """Extracts and transforms PPM tariff component data from annex 9 for Electricity: Single-Rate Metering Arrangement, Typical consumption."""
+    sheet_start_row = 104
+    levelisation = True
+    type_of_consumption = "Typical consumption"
+    table_number = 1
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+# Gas
+def process_tariff_gas_ppm_nil():
+    """Extracts and transforms PPM tariff component data from annex 9 for Gas, Nil consumption."""
+    sheet_start_row = 88
+    levelisation = True
+    type_of_consumption = "Nil consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )
+
+
+def process_tariff_gas_ppm_typical():
+    """Extracts and transforms PPM tariff component data from annex 9 for Gas, Typical consumption."""
+    sheet_start_row = 104
+    levelisation = True
+    type_of_consumption = "Typical consumption"
+    table_number = 3
+    return _process_tariff(
+        sheet_start_row, levelisation, type_of_consumption, table_number
+    )

--- a/asf_levies_model/getters/load_data.py
+++ b/asf_levies_model/getters/load_data.py
@@ -501,11 +501,14 @@ def _extract_single_tariff_table(
     # Table without first row
     single_tariff_table_df = single_tariff_table_df.iloc[1:, :]
     # Replace "-" with na
-    single_tariff_table_df = single_tariff_table_df.replace(
-        "[\u002D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A\u2E3A\u2E3B\u2E40\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D]",
-        None,
-        regex=True,
-    )
+    with warnings.catch_warnings():
+        # Suppress Future warning for replace.
+        warnings.simplefilter("ignore")
+        single_tariff_table_df = single_tariff_table_df.replace(
+            "[\u002D\u058A\u05BE\u1400\u1806\u2010-\u2015\u2E17\u2E1A\u2E3A\u2E3B\u2E40\u301C\u3030\u30A0\uFE31\uFE32\uFE58\uFE63\uFF0D]",
+            None,
+            regex=True,
+        )
     return single_tariff_table_df
 
 
@@ -531,12 +534,16 @@ def _tidy_tariff_table(
         id_vars=type_of_consumption, var_name="28AD_Charge_Restriction_Period"
     )
     # Add start and end dates
-    tidy_df["28AD_Charge_Restriction_Period_start"] = pd.to_datetime(
-        tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[0]
-    )
-    tidy_df["28AD_Charge_Restriction_Period_end"] = pd.to_datetime(
-        tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[1]
-    )
+    with warnings.catch_warnings():
+        # Suppress warning for datetime parsing each element individually.
+        # Dates in this table are a mess and this is desired behaviour.
+        warnings.simplefilter("ignore")
+        tidy_df["28AD_Charge_Restriction_Period_start"] = pd.to_datetime(
+            tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[0]
+        )
+        tidy_df["28AD_Charge_Restriction_Period_end"] = pd.to_datetime(
+            tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[1]
+        )
 
     return tidy_df
 

--- a/asf_levies_model/notebooks/model_example.py
+++ b/asf_levies_model/notebooks/model_example.py
@@ -1,3 +1,20 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: asf_levies_model
+#     language: python
+#     name: python3
+# ---
+
 # %%
 from asf_levies_model.getters.load_data import (
     download_annex_4,
@@ -8,21 +25,37 @@ from asf_levies_model.getters.load_data import (
     process_data_ECO,
     process_data_FIT,
     download_annex_9,
-    slice_tariff_components_tables,
-    extract_single_tariff_table,
-    tidy_tariff_table,
+    process_tariff_elec_standard_credit_nil,
+    process_tariff_elec_standard_credit_typical,
+    process_tariff_gas_standard_credit_nil,
+    process_tariff_gas_standard_credit_typical,
+    process_tariff_elec_other_payment_nil,
+    process_tariff_elec_other_payment_typical,
+    process_tariff_gas_other_payment_nil,
+    process_tariff_gas_other_payment_typical,
+    process_tariff_elec_ppm_nil,
+    process_tariff_elec_ppm_typical,
+    process_tariff_gas_ppm_nil,
+    process_tariff_gas_ppm_typical,
 )
 
 from asf_levies_model.levies import RO, AAHEDC, GGL, WHD, ECO, FIT
 
-from asf_levies_model.tariffs import ElectricityStandardCredit, GasStandardCredit
+from asf_levies_model.tariffs import (
+    ElectricityStandardCredit,
+    GasStandardCredit,
+    ElectricityOtherPayment,
+    GasOtherPayment,
+    ElectricityPPM,
+    GasPPM,
+)
 
 # %% [markdown]
 # ### Policy Costs
 
 # %%
 # Example downloading annex 4
-url = "https://www.ofgem.gov.uk/sites/default/files/2024-03/Annex_4_-_Policy_cost_allowance_methodology_v1.18.xlsx"
+url = "https://www.ofgem.gov.uk/sites/default/files/2024-08/Annex_4_-_Policy_cost_allowance_methodology_v1.19%20%281%29.xlsx"
 download_annex_4(url)
 
 # %%
@@ -48,7 +81,7 @@ levies = [
 
 # %%
 # get sum of policy costs for typical consumption
-sum([levy.calculate_levy(2.7, 0, True, False) for levy in levies])
+sum([levy.calculate_levy(2.7, 11.5, True, True) for levy in levies])
 
 # %%
 # deonminators from subnational consumption estimates
@@ -195,30 +228,18 @@ sum([levy.calculate_levy(2.7, 11.5, True, True) for levy in gas_fixed_levies])
 # %%
 # Getting annex 9
 
-url = "https://www.ofgem.gov.uk/sites/default/files/2024-05/Annex%209%20-%20Levelisation%20allowance%20methodology%20and%20levelised%20cap%20levels%20v1.2.xlsx"
+url = "https://www.ofgem.gov.uk/sites/default/files/2024-08/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.3.xlsx"
 download_annex_9(url)
 
 # %% [markdown]
-# #### Electricity
+# #### Standard Credit
+
+# %% [markdown]
+# ##### Electricity
 
 # %%
-elec_standard_credit_nil = tidy_tariff_table(
-    extract_single_tariff_table(
-        slice_tariff_components_tables(sheet_start_row=55, levelisation=False),
-        "Nil consumption",
-        table_number=1,
-    ),
-    "Nil consumption",
-)
-
-elec_standard_credit_typical = tidy_tariff_table(
-    extract_single_tariff_table(
-        slice_tariff_components_tables(sheet_start_row=70, levelisation=False),
-        "Typical consumption",
-        table_number=1,
-    ),
-    "Typical consumption",
-)
+elec_standard_credit_nil = process_tariff_elec_standard_credit_nil()
+elec_standard_credit_typical = process_tariff_elec_standard_credit_typical()
 
 # %%
 # Create a tariff object
@@ -242,26 +263,11 @@ elec_bill.pc = sum([levy.calculate_variable_levy(1, 0) for levy in levies])
 elec_bill.calculate_total_consumption(2.7)
 
 # %% [markdown]
-# #### Gas
+# ##### Gas
 
 # %%
-gas_standard_credit_nil = tidy_tariff_table(
-    extract_single_tariff_table(
-        slice_tariff_components_tables(sheet_start_row=55, levelisation=False),
-        "Nil consumption",
-        table_number=3,
-    ),
-    "Nil consumption",
-)
-
-gas_standard_credit_typical = tidy_tariff_table(
-    extract_single_tariff_table(
-        slice_tariff_components_tables(sheet_start_row=70, levelisation=False),
-        "Typical consumption",
-        table_number=3,
-    ),
-    "Typical consumption",
-)
+gas_standard_credit_nil = process_tariff_gas_standard_credit_nil()
+gas_standard_credit_typical = process_tariff_gas_standard_credit_typical()
 
 # %%
 # Create
@@ -281,4 +287,74 @@ gas_bill.pc = sum([levy.calculate_variable_levy(0, 1) for levy in levies])
 
 # %%
 # Check it works - its the same!
+gas_bill.calculate_total_consumption(11.5)
+
+# %% [markdown]
+# #### Other Payment Method
+
+# %% [markdown]
+# ##### Electricity
+
+# %%
+elec_other_payment_nil = process_tariff_elec_other_payment_nil()
+elec_other_payment_typical = process_tariff_elec_other_payment_typical()
+
+# %%
+# Create a tariff object
+elec_bill = ElectricityOtherPayment.from_dataframe(
+    elec_other_payment_nil, elec_other_payment_typical
+)
+
+# %%
+# This is the bill with default values.
+elec_bill.calculate_total_consumption(2.7)
+
+# %% [markdown]
+# ##### Gas
+
+# %%
+gas_other_payment_nil = process_tariff_gas_other_payment_nil()
+gas_other_payment_typical = process_tariff_gas_other_payment_typical()
+
+# %%
+# Create
+gas_bill = GasOtherPayment.from_dataframe(
+    gas_other_payment_nil, gas_other_payment_typical
+)
+
+# %%
+# This is the bill with default values.
+gas_bill.calculate_total_consumption(11.5)
+
+# %% [markdown]
+# #### PPM
+
+# %% [markdown]
+# ##### Electricity
+
+# %%
+elec_ppm_nil = process_tariff_elec_ppm_nil()
+elec_ppm_typical = process_tariff_elec_ppm_typical()
+
+# %%
+# Create a tariff object
+elec_bill = ElectricityPPM.from_dataframe(elec_ppm_nil, elec_ppm_typical)
+
+# %%
+# This is the bill with default values.
+elec_bill.calculate_total_consumption(2.7)
+
+# %% [markdown]
+# ##### Gas
+
+# %%
+gas_ppm_nil = process_tariff_gas_ppm_nil()
+gas_ppm_typical = process_tariff_gas_ppm_typical()
+
+# %%
+# Create
+gas_bill = GasPPM.from_dataframe(gas_ppm_nil, gas_ppm_typical)
+
+# %%
+# This is the bill with default values.
 gas_bill.calculate_total_consumption(11.5)

--- a/asf_levies_model/notebooks/price_ratio_calculation_example.py
+++ b/asf_levies_model/notebooks/price_ratio_calculation_example.py
@@ -1,0 +1,280 @@
+# %%
+from asf_levies_model.getters.load_data import (
+    download_annex_4,
+    process_data_RO,
+    process_data_AAHEDC,
+    process_data_GGL,
+    process_data_WHD,
+    process_data_ECO,
+    process_data_FIT,
+    download_annex_9,
+    process_tariff_elec_standard_credit_nil,
+    process_tariff_elec_standard_credit_typical,
+    process_tariff_gas_standard_credit_nil,
+    process_tariff_gas_standard_credit_typical,
+    process_tariff_elec_other_payment_nil,
+    process_tariff_elec_other_payment_typical,
+    process_tariff_gas_other_payment_nil,
+    process_tariff_gas_other_payment_typical,
+    process_tariff_elec_ppm_nil,
+    process_tariff_elec_ppm_typical,
+    process_tariff_gas_ppm_nil,
+    process_tariff_gas_ppm_typical,
+    ofgem_archetypes_data,
+)
+
+from asf_levies_model.levies import RO, AAHEDC, GGL, WHD, ECO, FIT
+
+from asf_levies_model.tariffs import (
+    ElectricityStandardCredit,
+    GasStandardCredit,
+    ElectricityOtherPayment,
+    GasOtherPayment,
+    ElectricityPPM,
+    GasPPM,
+)
+
+# %% [markdown]
+# Extracting tariff cost components: Other Payment method
+
+# %%
+# Getting annex 9
+url = "https://www.ofgem.gov.uk/sites/default/files/2024-08/Annex_9_-_Levelisation_allowance_methodology_and_levelised_cap_levels_v1.3.xlsx"
+download_annex_9(url)
+
+# %%
+# Create electricity bill object
+elec_other_payment_nil = process_tariff_elec_other_payment_nil()
+elec_other_payment_typical = process_tariff_elec_other_payment_typical()
+elec_bill = ElectricityOtherPayment.from_dataframe(
+    elec_other_payment_nil, elec_other_payment_typical
+)
+# Create gas bill object
+gas_other_payment_nil = process_tariff_gas_other_payment_nil()
+gas_other_payment_typical = process_tariff_gas_other_payment_typical()
+gas_bill = GasOtherPayment.from_dataframe(
+    gas_other_payment_nil, gas_other_payment_typical
+)
+
+# %% [markdown]
+# With current policy costs (status quo levy rates)
+
+# %%
+archetype_data = ofgem_archetypes_data()
+archetype_data
+
+# %%
+archetype_data["Electricity bill"] = elec_bill.calculate_total_consumption(
+    archetype_data["ElectricitySingleRatekWh"] / 1_000, vat=True
+)
+archetype_data["Gas bill"] = gas_bill.calculate_total_consumption(
+    archetype_data["GaskWh"] / 1_000, vat=True
+)
+archetype_data["Electricity unit cost"] = (
+    archetype_data["Electricity bill"] / archetype_data["ElectricitySingleRatekWh"]
+)
+archetype_data["Gas unit cost"] = archetype_data["Gas bill"] / archetype_data["GaskWh"]
+archetype_data["Electricity to gas price ratio"] = (
+    archetype_data["Electricity unit cost"] / archetype_data["Gas unit cost"]
+)
+
+archetype_data
+
+# %%
+archetype_data.loc[
+    :,
+    [
+        "AnnualConsumptionProfile",
+        "Electricity unit cost",
+        "Gas unit cost",
+        "Electricity to gas price ratio",
+    ],
+]
+
+# %% [markdown]
+# ### What is the theoretical minimum ratio that is possible for a given consumption profile (if we're only able to change policy costs)?
+# - Ratio = (Electricity bill/Electricity consumption) / (Gas bill/Gas consumption)
+# - We want to make the numerator as small as possible and denominator as big as possible
+# - Electricity policy costs = 0
+# - Gas policy costs -> which one of fixed vs variable charges makes this bigger?
+
+# %%
+# Define constants
+DOMESTIC_CUSTOMERS_ELEC = 29_078_770  # customers
+DOMESTIC_CUSTOMERS_GAS = 24_503_683  # customers
+DOMESTIC_SUPPLY_ELEC = 94_200_366  # MWh
+DOMESTIC_SUPPLY_GAS = 265_197_947  # MWh
+
+REVENUE_GGL = 0.38325 * DOMESTIC_CUSTOMERS_GAS
+REVENUE_WHD = 553_000_000
+REVENUE_AAHEDC = 0.42145 * DOMESTIC_SUPPLY_ELEC
+REVENUE_ECO = 1_435_000_000
+REVENUE_RO = 31.78 * DOMESTIC_SUPPLY_ELEC
+REVENUE_FIT = 689_233_317  # domestic share based on domestic electricity supply/total eligible supply
+
+# %%
+# Take a basis of a theoretical revenue
+revenue = 1_000_000
+
+# What is the policy cost to a typical consumer if charging base is customers (fixed levy rate)
+levy_fixed = revenue / DOMESTIC_CUSTOMERS_GAS
+policy_cost_fixed = levy_fixed
+
+# What is the policy cost to a typical consumer if charging base is gas units (variable levy rate)
+levy_variable = revenue / DOMESTIC_SUPPLY_GAS
+policy_cost_variable = levy_variable * 11.5
+
+print(policy_cost_fixed, policy_cost_variable)
+
+# %% [markdown]
+# **For a given policy scheme, the largest gas policy cost arises when the levy charging base is gas units.**<br>
+# Let's calculate the theoretical "floor" of the electricity to gas price ratio.
+
+# %%
+# Example downloading annex 4
+url = "https://www.ofgem.gov.uk/sites/default/files/2024-08/Annex_4_-_Policy_cost_allowance_methodology_v1.19%20%281%29.xlsx"
+download_annex_4(url)
+
+# Initialise the existing levies
+levies = [
+    RO.from_dataframe(
+        process_data_RO(), denominator=94_200_366
+    ),  # domestic denominator
+    AAHEDC.from_dataframe(
+        process_data_AAHEDC(), denominator=94_200_366
+    ),  # domestic denominator
+    GGL.from_dataframe(
+        process_data_GGL(), denominator=24_503_683
+    ),  # domestic denominator
+    WHD.from_dataframe(process_data_WHD()),  # domestic only levy
+    ECO.from_dataframe(process_data_ECO()),  # domestic only levy
+    FIT.from_dataframe(
+        process_data_FIT(),
+        revenue=689_233_317,  # This revenue is the domestic share based on domestic electricity supply/total elligible supply.
+    ),
+]
+
+# Using just domestic values for rebalancing
+domestic_values = {
+    "supply_elec": 94_200_366,
+    "supply_gas": 265_197_947,
+    "customers_gas": 24_503_683,
+    "customers_elec": 29_078_770,
+}
+denominators = {
+    key: domestic_values for key in ["ro", "aahedc", "ggl", "whd", "eco", "fit"]
+}
+
+# Rebalancing to 100% gas variable
+weights = {
+    "new_electricity_weight": 0,
+    "new_gas_weight": 1,
+    "new_tax_weight": 0,
+    "new_variable_weight_elec": 0,
+    "new_fixed_weight_elec": 0,
+    "new_variable_weight_gas": 1,
+    "new_fixed_weight_gas": 0,
+}
+
+# %%
+# Rebalance
+gas_var_levies = [
+    levy.rebalance_levy(**weights, **denominators[levy.short_name]) for levy in levies
+]
+
+# %%
+# Create new instance of electricity bill (theoretical)
+elec_bill_theoretical = ElectricityOtherPayment.from_dataframe(
+    elec_other_payment_nil, elec_other_payment_typical
+)
+
+# Update policy costs in bill
+elec_bill_theoretical.pc_nil = sum(
+    [levy.calculate_fixed_levy(True, False) for levy in gas_var_levies]
+)
+elec_bill_theoretical.pc = sum(
+    [levy.calculate_variable_levy(1, 0) for levy in gas_var_levies]
+)
+
+elec_pc_theoretical = (
+    elec_bill_theoretical.pc_nil - elec_bill_theoretical.pc * 2.7
+) * 1.05
+
+elec_pc_theoretical
+
+# %% [markdown]
+# How to make gas policy costs as big as possible?
+
+# %%
+# Create new instance of gas bill (theoretical)
+gas_bill_theoretical = GasOtherPayment.from_dataframe(
+    gas_other_payment_nil, gas_other_payment_typical
+)
+
+# %%
+# Update gas policy costs
+gas_bill_theoretical.pc_nil = sum(
+    [levy.calculate_fixed_levy(False, True) for levy in gas_var_levies]
+)
+gas_bill_theoretical.pc = sum(
+    [levy.calculate_variable_levy(0, 1) for levy in gas_var_levies]
+)
+gas_pc_theoretical = (
+    gas_bill_theoretical.pc_nil + (gas_bill_theoretical.pc * 11.5)
+) * 1.05
+
+gas_pc_theoretical
+
+# %%
+# Increase in policy costs (should be the same as increase in total bill)
+gas_pc = (gas_bill.pc_nil + gas_bill.pc * 11.5) * 1.05
+gas_pc_theoretical - gas_pc
+
+# %%
+# Compare current vs. theoretical gas bill cost
+gas_bill_cost = gas_bill.calculate_total_consumption(11.5, vat=True)
+gas_bill_cost_theoretical = gas_bill_theoretical.calculate_total_consumption(
+    11.5, vat=True
+)
+gas_bill_cost, gas_bill_cost_theoretical, gas_bill_cost_theoretical - gas_bill_cost
+
+# %%
+# Compare current vs. theoretical electricity bill cost
+elec_bill_cost = elec_bill.calculate_total_consumption(2.7, vat=True)
+
+elec_bill_cost_theoretical = elec_bill_theoretical.calculate_total_consumption(
+    2.7, vat=True
+)
+elec_bill_cost, elec_bill_cost_theoretical, elec_bill_cost_theoretical - elec_bill_cost
+
+# %%
+# Compare current vs. theoretical total bill
+total_bill_cost = elec_bill_cost + gas_bill_cost
+total_bill_cost_theoretical = elec_bill_cost_theoretical + gas_bill_cost_theoretical
+total_bill_cost, total_bill_cost_theoretical, total_bill_cost_theoretical - total_bill_cost
+
+# %%
+# New fuel bills
+elec_bill_cost_theoretical, gas_bill_cost_theoretical
+
+# %%
+# New unit costs
+elec_bill_cost_theoretical / 2700, gas_bill_cost_theoretical / 11500
+
+# %%
+# New price ratio
+theoretical_min_ratio = (elec_bill_cost_theoretical / 2.7) / (
+    gas_bill_cost_theoretical / 11.5
+)
+theoretical_min_ratio
+
+# %%
+# Required bill increase
+total_bill_cost_theoretical - total_bill_cost
+
+# %% [markdown]
+# **The theoretical "floor" of the electricity-to-gas price ratio (if we can only change policy costs and not any other tariff components) is 3.00. This corresponds to a £64.30 increase in the energy bill of a typical consumer**
+# - This is in line with the set of results we see in the optimisation model.
+
+# %% [markdown]
+#

--- a/asf_levies_model/tariffs.py
+++ b/asf_levies_model/tariffs.py
@@ -471,3 +471,563 @@ class GasStandardCredit(Tariff):
             hap=typical_latest["HAP"],
             levelisation=None,
         )
+
+
+class ElectricityOtherPayment(Tariff):
+    """Electricity Other Payment Method Tariff.\n"""
+
+    __doc__ += (
+        Tariff.__doc__.split("\n", maxsplit=4)[4]
+        + """\
+"""
+    )
+
+    def __init__(
+        self,
+        name: str,
+        short_name: str,
+        fuel: str,
+        df_nil: float,
+        cm_nil: float,
+        aa_nil: float,
+        pc_nil: float,
+        nc_nil: float,
+        oc_nil: float,
+        smncc_nil: float,
+        paac_nil: float,
+        pap_nil: float,
+        ebit_nil: float,
+        hap_nil: float,
+        levelisation_nil: float,
+        df: float,
+        cm: float,
+        aa: float,
+        pc: float,
+        nc: float,
+        oc: float,
+        smncc: float,
+        paac: float,
+        pap: float,
+        ebit: float,
+        hap: float,
+        levelisation: float,
+    ) -> None:
+        super(ElectricityOtherPayment, self).__init__(
+            name,
+            short_name,
+            fuel,
+            df_nil,
+            cm_nil,
+            aa_nil,
+            pc_nil,
+            nc_nil,
+            oc_nil,
+            smncc_nil,
+            paac_nil,
+            pap_nil,
+            ebit_nil,
+            hap_nil,
+            levelisation_nil,
+            df,
+            cm,
+            aa,
+            pc,
+            nc,
+            oc,
+            smncc,
+            paac,
+            pap,
+            ebit,
+            hap,
+            levelisation,
+        )
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        nil_df: pd.DataFrame,
+        typical_df: pd.DataFrame,
+        typical_consumption: float = 2.7,
+    ) -> "ElectricityOtherPayment":
+        """Create ElectricityOtherPayment tariff instance from dataframe input.
+
+        `nil_df` and `typical_df` are tidy data tables derived from ofgem annex 9 using functions in \
+`asf_levies_model.getters.load_data`.
+
+        Uses a `typical_consumption` value (default: 2.7 MWh) to create unit rates from typical_df input.
+
+        Args:
+            nil_df: a dataframe with values for nil consumption.
+            typical_df: a dataframe with values for typical consumption.
+            typical_consumption: float, the typical consumption value used in `typical_df`.
+        """
+        # Get latest values from nil and typical dfs.
+        nil_latest = (
+            nil_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Nil consumption")
+            .loc[:, "value"]
+        )
+        typical_latest = (
+            typical_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Typical consumption")
+            .loc[:, "value"]
+        )
+
+        # Get unit costs per MWh
+        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+
+        return cls(
+            name="Other Payment Method. Electricity Single-Rate Metering Arrangement",
+            short_name="Electricity Other Payment",
+            fuel="electricity",
+            df_nil=nil_latest["DF"],
+            cm_nil=nil_latest["CM"],
+            aa_nil=nil_latest["AA"],
+            pc_nil=nil_latest["PC"],
+            nc_nil=nil_latest["NC"],
+            oc_nil=nil_latest["OC"],
+            smncc_nil=nil_latest["SMNCC"],
+            paac_nil=nil_latest["PAAC"],
+            pap_nil=nil_latest["PAP"],
+            ebit_nil=nil_latest["EBIT"],
+            hap_nil=nil_latest["HAP"],
+            levelisation_nil=nil_latest["Levelisation "],
+            df=typical_latest["DF"],
+            cm=typical_latest["CM"],
+            aa=typical_latest["AA"],
+            pc=typical_latest["PC"],
+            nc=typical_latest["NC"],
+            oc=typical_latest["OC"],
+            smncc=typical_latest["SMNCC"],
+            paac=typical_latest["PAAC"],
+            pap=typical_latest["PAP"],
+            ebit=typical_latest["EBIT"],
+            hap=typical_latest["HAP"],
+            levelisation=typical_latest["Levelisation "],
+        )
+
+
+class GasOtherPayment(Tariff):
+    """Gas Other Payment Tariff.\n"""
+
+    __doc__ += (
+        Tariff.__doc__.split("\n", maxsplit=4)[4]
+        + """\
+"""
+    )
+
+    def __init__(
+        self,
+        name: str,
+        short_name: str,
+        fuel: str,
+        df_nil: float,
+        cm_nil: float,
+        aa_nil: float,
+        pc_nil: float,
+        nc_nil: float,
+        oc_nil: float,
+        smncc_nil: float,
+        paac_nil: float,
+        pap_nil: float,
+        ebit_nil: float,
+        hap_nil: float,
+        levelisation_nil: float,
+        df: float,
+        cm: float,
+        aa: float,
+        pc: float,
+        nc: float,
+        oc: float,
+        smncc: float,
+        paac: float,
+        pap: float,
+        ebit: float,
+        hap: float,
+        levelisation: float,
+    ) -> None:
+        super(GasOtherPayment, self).__init__(
+            name,
+            short_name,
+            fuel,
+            df_nil,
+            cm_nil,
+            aa_nil,
+            pc_nil,
+            nc_nil,
+            oc_nil,
+            smncc_nil,
+            paac_nil,
+            pap_nil,
+            ebit_nil,
+            hap_nil,
+            levelisation_nil,
+            df,
+            cm,
+            aa,
+            pc,
+            nc,
+            oc,
+            smncc,
+            paac,
+            pap,
+            ebit,
+            hap,
+            levelisation,
+        )
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        nil_df: pd.DataFrame,
+        typical_df: pd.DataFrame,
+        typical_consumption: float = 11.5,
+    ) -> "GasOtherPayment":
+        """Create GasOtherPayment tariff instance from dataframe input.
+
+        `nil_df` and `typical_df` are tidy data tables derived from ofgem annex 9 using functions in \
+`asf_levies_model.getters.load_data`.
+
+        Uses a `typical_consumption` value (default: 11.5 MWh) to create unit rates from typical_df input.
+
+        Args:
+            nil_df: a dataframe with values for nil consumption.
+            typical_df: a dataframe with values for typical consumption.
+            typical_consumption: float, the typical consumption value used in `typical_df`.
+        """
+        # Get latest values from nil and typical dfs.
+        nil_latest = (
+            nil_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Nil consumption")
+            .loc[:, "value"]
+        )
+        typical_latest = (
+            typical_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Typical consumption")
+            .loc[:, "value"]
+        )
+
+        # Get unit costs per MWh
+        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+
+        return cls(
+            name="Other Payment Method. Gas",
+            short_name="Gas Other Payment",
+            fuel="gas",
+            df_nil=nil_latest["DF"],
+            cm_nil=nil_latest["CM"],
+            aa_nil=nil_latest["AA"],
+            pc_nil=nil_latest["PC"],
+            nc_nil=nil_latest["NC"],
+            oc_nil=nil_latest["OC"],
+            smncc_nil=nil_latest["SMNCC"],
+            paac_nil=nil_latest["PAAC"],
+            pap_nil=nil_latest["PAP"],
+            ebit_nil=nil_latest["EBIT"],
+            hap_nil=nil_latest["HAP"],
+            levelisation_nil=nil_latest["Levelisation "],
+            df=typical_latest["DF"],
+            cm=typical_latest["CM"],
+            aa=typical_latest["AA"],
+            pc=typical_latest["PC"],
+            nc=typical_latest["NC"],
+            oc=typical_latest["OC"],
+            smncc=typical_latest["SMNCC"],
+            paac=typical_latest["PAAC"],
+            pap=typical_latest["PAP"],
+            ebit=typical_latest["EBIT"],
+            hap=typical_latest["HAP"],
+            levelisation=typical_latest["Levelisation "],
+        )
+
+
+class ElectricityPPM(Tariff):
+    """Electricity PPM Tariff.\n"""
+
+    __doc__ += (
+        Tariff.__doc__.split("\n", maxsplit=4)[4]
+        + """\
+"""
+    )
+
+    def __init__(
+        self,
+        name: str,
+        short_name: str,
+        fuel: str,
+        df_nil: float,
+        cm_nil: float,
+        aa_nil: float,
+        pc_nil: float,
+        nc_nil: float,
+        oc_nil: float,
+        smncc_nil: float,
+        paac_nil: float,
+        pap_nil: float,
+        ebit_nil: float,
+        hap_nil: float,
+        levelisation_nil: float,
+        df: float,
+        cm: float,
+        aa: float,
+        pc: float,
+        nc: float,
+        oc: float,
+        smncc: float,
+        paac: float,
+        pap: float,
+        ebit: float,
+        hap: float,
+        levelisation: float,
+    ) -> None:
+        super(ElectricityPPM, self).__init__(
+            name,
+            short_name,
+            fuel,
+            df_nil,
+            cm_nil,
+            aa_nil,
+            pc_nil,
+            nc_nil,
+            oc_nil,
+            smncc_nil,
+            paac_nil,
+            pap_nil,
+            ebit_nil,
+            hap_nil,
+            levelisation_nil,
+            df,
+            cm,
+            aa,
+            pc,
+            nc,
+            oc,
+            smncc,
+            paac,
+            pap,
+            ebit,
+            hap,
+            levelisation,
+        )
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        nil_df: pd.DataFrame,
+        typical_df: pd.DataFrame,
+        typical_consumption: float = 2.7,
+    ) -> "ElectricityPPM":
+        """Create ElectricityPPM tariff instance from dataframe input.
+
+        `nil_df` and `typical_df` are tidy data tables derived from ofgem annex 9 using functions in \
+`asf_levies_model.getters.load_data`.
+
+        Uses a `typical_consumption` value (default: 2.7 MWh) to create unit rates from typical_df input.
+
+        Args:
+            nil_df: a dataframe with values for nil consumption.
+            typical_df: a dataframe with values for typical consumption.
+            typical_consumption: float, the typical consumption value used in `typical_df`.
+        """
+        # Get latest values from nil and typical dfs.
+        nil_latest = (
+            nil_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Nil consumption")
+            .loc[:, "value"]
+        )
+        typical_latest = (
+            typical_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Typical consumption")
+            .loc[:, "value"]
+        )
+
+        # Get unit costs per MWh
+        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+
+        return cls(
+            name="PPM. Electricity Single-Rate Metering Arrangement",
+            short_name="Electricity PPM",
+            fuel="electricity",
+            df_nil=nil_latest["DF"],
+            cm_nil=nil_latest["CM"],
+            aa_nil=nil_latest["AA"],
+            pc_nil=nil_latest["PC"],
+            nc_nil=nil_latest["NC"],
+            oc_nil=nil_latest["OC"],
+            smncc_nil=nil_latest["SMNCC"],
+            paac_nil=nil_latest["PAAC"],
+            pap_nil=nil_latest["PAP"],
+            ebit_nil=nil_latest["EBIT"],
+            hap_nil=nil_latest["HAP"],
+            levelisation_nil=nil_latest["Levelisation "],
+            df=typical_latest["DF"],
+            cm=typical_latest["CM"],
+            aa=typical_latest["AA"],
+            pc=typical_latest["PC"],
+            nc=typical_latest["NC"],
+            oc=typical_latest["OC"],
+            smncc=typical_latest["SMNCC"],
+            paac=typical_latest["PAAC"],
+            pap=typical_latest["PAP"],
+            ebit=typical_latest["EBIT"],
+            hap=typical_latest["HAP"],
+            levelisation=typical_latest["Levelisation "],
+        )
+
+
+class GasPPM(Tariff):
+    """Gas PPM Tariff.\n"""
+
+    __doc__ += (
+        Tariff.__doc__.split("\n", maxsplit=4)[4]
+        + """\
+"""
+    )
+
+    def __init__(
+        self,
+        name: str,
+        short_name: str,
+        fuel: str,
+        df_nil: float,
+        cm_nil: float,
+        aa_nil: float,
+        pc_nil: float,
+        nc_nil: float,
+        oc_nil: float,
+        smncc_nil: float,
+        paac_nil: float,
+        pap_nil: float,
+        ebit_nil: float,
+        hap_nil: float,
+        levelisation_nil: float,
+        df: float,
+        cm: float,
+        aa: float,
+        pc: float,
+        nc: float,
+        oc: float,
+        smncc: float,
+        paac: float,
+        pap: float,
+        ebit: float,
+        hap: float,
+        levelisation: float,
+    ) -> None:
+        super(GasPPM, self).__init__(
+            name,
+            short_name,
+            fuel,
+            df_nil,
+            cm_nil,
+            aa_nil,
+            pc_nil,
+            nc_nil,
+            oc_nil,
+            smncc_nil,
+            paac_nil,
+            pap_nil,
+            ebit_nil,
+            hap_nil,
+            levelisation_nil,
+            df,
+            cm,
+            aa,
+            pc,
+            nc,
+            oc,
+            smncc,
+            paac,
+            pap,
+            ebit,
+            hap,
+            levelisation,
+        )
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        nil_df: pd.DataFrame,
+        typical_df: pd.DataFrame,
+        typical_consumption: float = 11.5,
+    ) -> "GasPPM":
+        """Create GasPPM tariff instance from dataframe input.
+
+        `nil_df` and `typical_df` are tidy data tables derived from ofgem annex 9 using functions in \
+`asf_levies_model.getters.load_data`.
+
+        Uses a `typical_consumption` value (default: 11.5 MWh) to create unit rates from typical_df input.
+
+        Args:
+            nil_df: a dataframe with values for nil consumption.
+            typical_df: a dataframe with values for typical consumption.
+            typical_consumption: float, the typical consumption value used in `typical_df`.
+        """
+        # Get latest values from nil and typical dfs.
+        nil_latest = (
+            nil_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Nil consumption")
+            .loc[:, "value"]
+        )
+        typical_latest = (
+            typical_df.loc[
+                lambda df: df["28AD_Charge_Restriction_Period_start"]
+                == df["28AD_Charge_Restriction_Period_start"].max()
+            ]
+            .set_index("Typical consumption")
+            .loc[:, "value"]
+        )
+
+        # Get unit costs per MWh
+        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+
+        return cls(
+            name="PPM. Gas",
+            short_name="Gas PPM",
+            fuel="gas",
+            df_nil=nil_latest["DF"],
+            cm_nil=nil_latest["CM"],
+            aa_nil=nil_latest["AA"],
+            pc_nil=nil_latest["PC"],
+            nc_nil=nil_latest["NC"],
+            oc_nil=nil_latest["OC"],
+            smncc_nil=nil_latest["SMNCC"],
+            paac_nil=nil_latest["PAAC"],
+            pap_nil=nil_latest["PAP"],
+            ebit_nil=nil_latest["EBIT"],
+            hap_nil=nil_latest["HAP"],
+            levelisation_nil=nil_latest["Levelisation "],
+            df=typical_latest["DF"],
+            cm=typical_latest["CM"],
+            aa=typical_latest["AA"],
+            pc=typical_latest["PC"],
+            nc=typical_latest["NC"],
+            oc=typical_latest["OC"],
+            smncc=typical_latest["SMNCC"],
+            paac=typical_latest["PAAC"],
+            pap=typical_latest["PAP"],
+            ebit=typical_latest["EBIT"],
+            hap=typical_latest["HAP"],
+            levelisation=typical_latest["Levelisation "],
+        )


### PR DESCRIPTION
This set of changes introduces new tariff processing functionality. The following files have been changed/added:
1. `load_data.py`
- New pre-filled functions have been added to process each tariff table from Annex 9 (Other Payment method, Standard Credit, PPM for electricity and gas)
2. `tariffs.py`
- New child tariff classes have been added for Other Payment method tariff (electricity and gas) and PPM tariff (electricity and gas)
3. `model_example.py`
- Added examples of processing Other Payment and PPM tariff costs
4. `price_ratio_calculation_example.py`
- Exploratory notebook calculating the electricity-to-gas price ratio for each energy archetype and investigating the theoretical minimum ratio for typical consumption

Please could you review the new code in `load_data.py` and `tariffs.py` checking for any errors, missing documentation and opportunities for improvement/streamlining. How they are used is demonstrated in `model_example.py` and `price_ratio_calculation_example.py`.


