### PR TITLE
Processing functions to add targeted rebates to bills

### DIFF
--- a/asf_levies_model/notebooks/rebates_targeting_development.py
+++ b/asf_levies_model/notebooks/rebates_targeting_development.py
@@ -229,3 +229,28 @@ subsidisation_table(
 )
 
 # %%
+# Criteria from income decile table
+subsidisation_table(
+    scenario_outputs,
+    scenario_name,
+    rebate=150,
+    eligibility_criteria="Income Deciles",
+    eligibility_dataframe=transform_income_decile_eligibility(
+        ofgem_archetypes_net_income_deciles(), eligible_deciles=4
+    ),
+    eligible_deciles=4,
+    ineligible_households_pay=False,
+)
+
+# %%
+# Testing eligibility criteria validation
+subsidisation_table(
+    scenario_outputs,
+    scenario_name,
+    rebate=150,
+    eligibility_criteria="NotAScheme",
+    eligibility_dataframe=ofgem_archetypes_scheme_eligibility(),
+    ineligible_households_pay=False,
+)
+
+# %%

--- a/asf_levies_model/notebooks/rebates_targeting_development.py
+++ b/asf_levies_model/notebooks/rebates_targeting_development.py
@@ -1,0 +1,231 @@
+import pandas as pd
+
+from asf_levies_model.getters.load_data import (
+    download_annex_4,
+    download_annex_9,
+    process_data_RO,
+    process_data_AAHEDC,
+    process_data_GGL,
+    process_data_WHD,
+    process_data_ECO,
+    process_data_FIT,
+    process_tariff_elec_other_payment_nil,
+    process_tariff_elec_other_payment_typical,
+    process_tariff_gas_other_payment_nil,
+    process_tariff_gas_other_payment_typical,
+    ofgem_archetypes_data,
+    ofgem_archetypes_scheme_eligibility,
+    ofgem_archetypes_equivalised_income_deciles,
+    ofgem_archetypes_net_income_deciles,
+    ofgem_archetypes_retired_pension,
+)
+
+from asf_levies_model.levies import RO, AAHEDC, GGL, WHD, ECO, FIT
+
+from asf_levies_model.tariffs import ElectricityOtherPayment, GasOtherPayment
+
+from asf_levies_model.summary import (
+    process_rebalancing_scenarios,
+    process_rebalancing_scenario_bills,
+    subsidisation_table,
+    transform_income_decile_eligibility,
+)
+
+# %%
+# Annex 4 and initialise levies
+fileobject = download_annex_4(as_fileobject=True)
+levies = [
+    RO.from_dataframe(process_data_RO(fileobject), denominator=94_200_366),
+    AAHEDC.from_dataframe(process_data_AAHEDC(fileobject), denominator=94_200_366),
+    GGL.from_dataframe(process_data_GGL(fileobject), denominator=24_503_683),
+    WHD.from_dataframe(process_data_WHD(fileobject)),
+    ECO.from_dataframe(process_data_ECO(fileobject)),
+    FIT.from_dataframe(process_data_FIT(fileobject), revenue=689_233_317),
+]
+fileobject.close()
+
+# %%
+# Annex 9 and initialise tariffs (Other Payment method)
+fileobject = download_annex_9(as_fileobject=True)
+elec_other_payment_nil = process_tariff_elec_other_payment_nil(fileobject)
+elec_other_payment_typical = process_tariff_elec_other_payment_typical(fileobject)
+gas_other_payment_nil = process_tariff_gas_other_payment_nil(fileobject)
+gas_other_payment_typical = process_tariff_gas_other_payment_typical(fileobject)
+fileobject.close()
+
+# %%
+# Load archetypes headline data
+ofgem_archetypes_df = ofgem_archetypes_data()
+
+# %%
+# Set denominator values
+supply_elec = 94_200_366
+supply_gas = 265_197_947
+customers_gas = 24_503_683
+customers_elec = 29_078_770
+
+denominator_values = {
+    "supply_elec": supply_elec,
+    "supply_gas": supply_gas,
+    "customers_gas": customers_gas,
+    "customers_elec": customers_elec,
+}
+denominators = {
+    key: denominator_values for key in ["ro", "aahedc", "ggl", "whd", "eco", "fit"]
+}
+
+# %%
+# Rebalance baseline to reflect denominators
+status_quo = {}  # Recreating status quo
+for levy in levies:
+    status_quo[levy.short_name] = {
+        "new_electricity_weight": levy.electricity_weight,
+        "new_gas_weight": levy.gas_weight,
+        "new_tax_weight": levy.tax_weight,
+        "new_variable_weight_elec": levy.electricity_variable_weight,
+        "new_fixed_weight_elec": levy.electricity_fixed_weight,
+        "new_variable_weight_gas": levy.gas_variable_weight,
+        "new_fixed_weight_gas": levy.gas_fixed_weight,
+    }
+
+# manually update WHD weights according to denominator balance
+status_quo["whd"]["new_electricity_weight"] = denominators["whd"]["customers_elec"] / (
+    denominators["whd"]["customers_elec"] + denominators["whd"]["customers_gas"]
+)
+status_quo["whd"]["new_gas_weight"] = denominators["whd"]["customers_gas"] / (
+    denominators["whd"]["customers_elec"] + denominators["whd"]["customers_gas"]
+)
+
+# rebalance baseline levies
+levies = [
+    levy.rebalance_levy(
+        **status_quo.get(levy.short_name), **denominators.get(levy.short_name)
+    )
+    for levy in levies
+]
+
+# %%
+# Set scenario and rebalancing weights
+scenario_name = "100% gas, variable"
+
+gas_variable_weights = {
+    "new_electricity_weight": 0,
+    "new_gas_weight": 1,
+    "new_tax_weight": 0,
+    "new_variable_weight_elec": 0,
+    "new_fixed_weight_elec": 0,
+    "new_variable_weight_gas": 1,
+    "new_fixed_weight_gas": 0,
+}
+
+weights = {
+    scenario_name: {
+        key: gas_variable_weights
+        for key in ["ro", "aahedc", "ggl", "whd", "eco", "fit"]
+    },
+}
+
+# %%
+# Create bill objects
+elec_bills = {
+    "baseline": ElectricityOtherPayment.from_dataframe(
+        elec_other_payment_nil, elec_other_payment_typical
+    ),
+    scenario_name: ElectricityOtherPayment.from_dataframe(
+        elec_other_payment_nil, elec_other_payment_typical
+    ),
+}
+gas_bills = {
+    "baseline": GasOtherPayment.from_dataframe(
+        gas_other_payment_nil, gas_other_payment_typical
+    ),
+    scenario_name: GasOtherPayment.from_dataframe(
+        gas_other_payment_nil, gas_other_payment_typical
+    ),
+}
+
+# Update baseline bill policy costs to match denominator adjusted policy costs.
+elec_bills["baseline"].pc_nil = sum(
+    [levy.calculate_levy(0, 0, True, False) for levy in levies]
+)
+elec_bills["baseline"].pc = sum(
+    [levy.calculate_levy(1, 0, False, False) for levy in levies]
+)
+gas_bills["baseline"].pc_nil = sum(
+    [levy.calculate_levy(0, 0, False, True) for levy in levies]
+)
+gas_bills["baseline"].pc = sum(
+    [levy.calculate_levy(0, 1, False, False) for levy in levies]
+)
+
+# %%
+# Generate scenario outputs
+scenario_outputs = process_rebalancing_scenarios(
+    levies,
+    weights,
+    denominators,
+    ofgem_archetypes_df,
+    "AnnualConsumptionProfile",
+    "ElectricitySingleRatekWh",
+    "GaskWh",
+    ["fixed", "variable", "total"],
+    1_000,
+)
+
+scenario_bill_outputs = process_rebalancing_scenario_bills(
+    elec_bills,
+    gas_bills,
+    levies,
+    weights,
+    denominators,
+    ofgem_archetypes_df,
+    "AnnualConsumptionProfile",
+    "ElectricitySingleRatekWh",
+    "GaskWh",
+    1_000,
+    True,
+)
+
+# %%
+scenario_outputs = pd.concat([scenario_outputs, scenario_bill_outputs])
+
+# %% [markdown]
+# **Generating dataframe of new bills**
+
+# %%
+# Criteria from scheme eligibility table
+subsidisation_table(
+    scenario_outputs,
+    scenario_name,
+    rebate=150,
+    eligibility_criteria="ECO",
+    eligibility_dataframe=ofgem_archetypes_scheme_eligibility(),
+    ineligible_households_pay=False,
+)
+
+# %%
+# Criteria from retired/pension recipient table
+subsidisation_table(
+    scenario_outputs,
+    scenario_name,
+    rebate=150,
+    eligibility_criteria="Retired Economic Status",
+    eligibility_dataframe=ofgem_archetypes_retired_pension(),
+    ineligible_households_pay=False,
+)
+
+# %%
+# Criteria from income decile table
+subsidisation_table(
+    scenario_outputs,
+    scenario_name,
+    rebate=150,
+    eligibility_criteria="Income Deciles",
+    eligibility_dataframe=transform_income_decile_eligibility(
+        ofgem_archetypes_equivalised_income_deciles(), eligible_deciles=4
+    ),
+    eligible_deciles=4,
+    ineligible_households_pay=False,
+)
+
+# %%

--- a/asf_levies_model/summary.py
+++ b/asf_levies_model/summary.py
@@ -439,3 +439,152 @@ It is assumed that the rebalancing weights are the same for each levy.
     )
 
     return summary_bill_costs
+
+
+def transform_income_decile_eligibility(
+    decile_dataframe: pd.DataFrame, eligible_deciles: float
+) -> pd.DataFrame:
+    """Collapses columns of dataframes from ofgem_archetypes_equivalised_income_deciles() or ofgem_archetypes_net_income_deciles() to one column describing the total number of households in the eligible income deciles provided.
+
+    Parameters
+    ----------
+    decile_dataframe : pd.DataFrame
+        Dataframe from data loading functions ofgem_archetypes_equivalised_income_deciles() or ofgem_archetypes_net_income_deciles().
+    eligible_deciles : float
+        Desired number of eligible income deciles, e.g. 4 corresponds to the lowest 4 income deciles.
+
+    """
+    income_eligibility = decile_dataframe[
+        ["AnnualConsumptionProfile", "ArchetypeSize"]
+    ].copy(deep=True)
+
+    income_eligibility["Eligible income deciles"] = eligible_deciles
+
+    if eligible_deciles == 1:
+        income_eligibility["IncomeDecilesEligibilitySize"] = decile_dataframe.iloc[:, 2]
+
+    else:
+        income_eligibility["IncomeDecilesEligibilitySize"] = decile_dataframe.iloc[
+            :, 2 : eligible_deciles + 2
+        ].sum(axis=1)
+
+    return income_eligibility
+
+
+def subsidisation_table(
+    scenario_outputs: pd.DataFrame,
+    scenario_name: str,
+    rebate: float,
+    eligibility_criteria: str,
+    eligibility_dataframe: pd.DataFrame,
+    eligible_deciles: int = 0,
+    ineligible_households_pay: bool = True,
+) -> pd.DataFrame:
+    """Processes rebalancing scenario results to add a rebate for targeted vulnerable households.
+
+    Parameters
+    ----------
+    scenario_outputs : pd.DataFrame
+       Concatenated output dataframes from process_rebalancing_scenarios() and process_rebalancing_scenario_bills().
+    scenario_name : str
+        Name of scenario of interest, must match a scenario name present in scenario_outputs.
+    rebate : float
+        Amount to discount from eligible households' bills.
+    eligibility_dataframe : pd.DataFrame
+        Dataframe with a column of archetype names ("AnnualConsumptionProfile") and remaining columns listing the number of eligible households for a given criteria. Pre-processed dataframes include the outputs
+        from ofgem_archetypes_scheme_eligibility(), ofgem_archetypes_retired_pension() and transform_income_decile_eligibility(ofgem_archetypes_XX_income_deciles, eligible_deciles).
+    eligible_deciles : int, optional
+        Number of deciles qualify for eligibility criteria if based on income, e.g. 4 corresponds to the 4 lowest income deciles; by default 0.
+    ineligible_households_pay : bool, optional
+        Whether rebate fund should be equally distributed among ineligible household bills, by default True.
+
+    """
+
+    # Create new dataframe
+    bills = scenario_outputs[
+        (scenario_outputs["variable"] == "total bill incl VAT")
+        | (scenario_outputs["variable"] == "ArchetypeSize")
+    ]
+    bills = bills[bills["scenario"] == scenario_name]
+    bills = bills[bills.AnnualConsumptionProfile != "Typical"].reset_index(drop=True)
+    bills = bills.pivot_table(
+        index=[
+            "AnnualConsumptionProfile",
+            "scenario",
+        ],
+        columns="variable",
+        values="value",
+    ).reset_index()
+    bills = bills.rename(columns={"total bill incl VAT": "ScenarioBaseBill"})
+
+    # Add column for Current bills
+    baseline_bills = scenario_outputs[
+        (scenario_outputs["variable"] == "total bill incl VAT")
+        & (scenario_outputs["scenario"] == "Baseline")
+    ]
+    baseline_bills = baseline_bills[
+        baseline_bills.AnnualConsumptionProfile != "Typical"
+    ].reset_index()
+    bills.insert(3, "CurrentBaselineBill", baseline_bills["value"])
+
+    # Look up for eligibility criteria and column names
+    eligibility_dict = {
+        "Cold Weather Payments": "CWPEligibleSize",  # ofgem_archetypes_scheme_elibility()
+        "ECO": "ECOEligibleSize",  # ofgem_archetypes_scheme_elibility()
+        "Warm Homes Discount": "WHDEligibleSize",  # ofgem_archetypes_scheme_elibility()
+        "Winter Fuel Payments": "WFPEligibleSize",  # ofgem_archetypes_scheme_elibility()
+        "Retired Economic Status": "RetiredEconomicStatusSize",  # ofgem_archetypes_retired_pension()
+        "Pension Guarantee Credit": "PensionGuaranteeCreditRecipients",  # ofgem_archetypes_retired_pension()
+        "Pension Savings Credit": "PensionGuaranteeCreditRecipients",  # ofgem_archetypes_retired_pension()
+        "Income Deciles": "IncomeDecilesEligibilitySize",  # transform_income_decile_eligibility()
+    }
+
+    # If eligibility criteria not based on income deciles
+    if eligible_deciles == 0:
+        bills["EligibilityCriteria"] = eligibility_criteria
+
+    # If eligibility criteria is based on income deciles
+    else:
+        bills["EligibilityCriteria"] = (
+            str(eligible_deciles) + " Lowest " + eligibility_criteria
+        )
+
+    def find_eligible_size(row, eligibility_criteria):
+        return eligibility_dataframe.loc[
+            eligibility_dataframe["AnnualConsumptionProfile"] == row,
+            eligibility_criteria,
+        ].values[0]
+
+    # Add column for number of eligible households
+    bills["NumberOfEligibleHouseholds"] = bills["AnnualConsumptionProfile"].apply(
+        find_eligible_size, args=(eligibility_dict.get(eligibility_criteria),)
+    )
+
+    # Add column for total funds needed to provide rebate for eligible households in archetype
+    bills["TotalRequiredRebateAmount"] = rebate * bills["NumberOfEligibleHouseholds"]
+
+    # Add columns for new bill and bill change with respect to current bills for eligible households
+    bills["EligibleHouseholdBill"] = bills["ScenarioBaseBill"] - rebate
+    bills["EligibleHouseholdBillChangeFromCurrentBill"] = (
+        bills["EligibleHouseholdBill"] - bills["CurrentBaselineBill"]
+    )
+
+    # Add column for number of ineligible households
+    bills["NumberOfIneligibleHouseholds"] = (
+        bills["ArchetypeSize"] - bills["NumberOfEligibleHouseholds"]
+    )
+    rebate_fund = rebate * bills["NumberOfEligibleHouseholds"].sum()
+
+    # Add columns for new bill and bill change with respect to current bills for ineligible households
+    # If rebate mechanism does or does not involve ineligible households covering the costs
+    if ineligible_households_pay:
+        rebate_payment = rebate_fund / bills["NumberOfIneligibleHouseholds"].sum()
+        bills["IneligibleHouseholdBill"] = bills["ScenarioBaseBill"] + rebate_payment
+    else:
+        bills["IneligibleHouseholdBill"] = bills["ScenarioBaseBill"]
+
+    bills["IneligibleHouseholdBillChangeFromCurrentBill"] = (
+        bills["IneligibleHouseholdBill"] - bills["CurrentBaselineBill"]
+    )
+
+    return bills

--- a/asf_levies_model/summary.py
+++ b/asf_levies_model/summary.py
@@ -490,8 +490,11 @@ def subsidisation_table(
         Name of scenario of interest, must match a scenario name present in scenario_outputs.
     rebate : float
         Amount to discount from eligible households' bills.
+    eligibility_criteria : str
+        Criteria description, currently only accepts the following: ['Cold Weather Payments','ECO', 'Warm Homes Discount', 'Winter Fuel Payments', 'Retired Economic Status', 'Pension Guarantee Credit', 'Pension Savings Credit', 'Income Deciles'].
+        Else, a KeyError is raised.
     eligibility_dataframe : pd.DataFrame
-        Dataframe with a column of archetype names ("AnnualConsumptionProfile") and remaining columns listing the number of eligible households for a given criteria. Pre-processed dataframes include the outputs
+        Dataframe with a column of archetype names (column header "AnnualConsumptionProfile") and remaining columns listing the number of eligible households for a given criteria. Pre-processed dataframes include the outputs
         from ofgem_archetypes_scheme_eligibility(), ofgem_archetypes_retired_pension() and transform_income_decile_eligibility(ofgem_archetypes_XX_income_deciles, eligible_deciles).
     eligible_deciles : int, optional
         Number of deciles qualify for eligibility criteria if based on income, e.g. 4 corresponds to the 4 lowest income deciles; by default 0.
@@ -538,6 +541,11 @@ def subsidisation_table(
         "Pension Savings Credit": "PensionGuaranteeCreditRecipients",  # ofgem_archetypes_retired_pension()
         "Income Deciles": "IncomeDecilesEligibilitySize",  # transform_income_decile_eligibility()
     }
+
+    if eligibility_criteria not in eligibility_dict.keys():
+        raise KeyError(
+            f"Please provide criteria type from the following: {list(eligibility_dict.keys())}"
+        )
 
     # If eligibility criteria not based on income deciles
     if eligible_deciles == 0:


### PR DESCRIPTION
This code adds two new functions in the `summary.py` module.
- `transform_income_decile_elibiligity()` to transform the ofgem archetype income decile tables to calculate the number of eligible households in the lowest X income deciles.
- `subsidisation_table()` to process baseline scenario results tables to produce another results table with the bill values for eligibile/ineligible households for a given eligibility criteria and rebate value. At present, I've left the output dataframe in pivot table format, but am open for it to be melted into tidy format if you think that would be most useful.

In this PR, could you please:
- Review the new functions code and flag any bugs, efficiency improvement opportunities, missing documentation.
- Check that the functions work as expected, you can do this in the new notebook I've set up `rebates_targeting_development.py`. 

---

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
