### PR TITLE
apply uprating to eco revenue method

### DIFF
--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -1160,10 +1160,22 @@ ObligatedSupplierVolumeElectricity, fields.
 
         if not revenue:
             revenue = (
-                latest.AnnualisedCostECO4Gas
-                + latest.AnnualisedCostECO4Electricity
-                + latest.AnnualisedCostGBISGas
-                + latest.AnnualisedCostGBISElectricity
+                (
+                    latest.AnnualisedCostECO4Gas
+                    * (1 + latest.GDPDeflatorToCurrentPricesECO4 / 100)
+                )
+                + (
+                    latest.AnnualisedCostECO4Electricity
+                    * (1 + latest.GDPDeflatorToCurrentPricesECO4 / 100)
+                )
+                + (
+                    latest.AnnualisedCostGBISGas
+                    * (1 + latest.GDPDeflatorToCurrentPricesGBIS / 100)
+                )
+                + (
+                    latest.AnnualisedCostGBISElectricity
+                    * (1 + latest.GDPDeflatorToCurrentPricesGBIS / 100)
+                )
             )
 
         return cls(


### PR DESCRIPTION
This code applies uprating to the ECO and GBIS annualised cost values to convert them to current prices. 

For this PR, please could you check that the calculation has been implemented correctly and also check if I missed any other methods for ECO that should also have this uprating applied.

Note: After merging this to dev, we need to merge this change to the streamlit_development branch.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
