### PR TITLE
Add revenue scaling factor

### DIFF
--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -1323,7 +1323,7 @@ class FIT(Levy):
 
     @classmethod
     def from_dataframe(
-        cls, df: pd.DataFrame, revenue: float = None, scaling_factor: float = None
+        cls, df: pd.DataFrame, revenue: float = None, scaling_factor: float = 1.0
     ) -> "FIT":
         """Create FIT levy instance from dataframe input.
 
@@ -1354,12 +1354,10 @@ ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fi
             latest.ExemptSupplyEII,
         )
 
-        if revenue:
-            if scaling_factor:
-                revenue = revenue * scaling_factor
+        if not revenue:
+            revenue = latest.InflatedLevelisationFund * scaling_factor
         else:
-            if scaling_factor:
-                revenue = latest.InflatedLevelisationFund * scaling_factor
+            revenue *= scaling_factor
 
         return cls(
             name="Feed in Tariff",

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -1322,7 +1322,9 @@ class FIT(Levy):
         self.ExemptSupplyEII = ExemptSupplyEII
 
     @classmethod
-    def from_dataframe(cls, df: pd.DataFrame, revenue: float = None) -> "FIT":
+    def from_dataframe(
+        cls, df: pd.DataFrame, revenue: float = None, scaling_factor: float = None
+    ) -> "FIT":
         """Create FIT levy instance from dataframe input.
 
         Uses the `process_data_FIT()` output from `asf_levies_model.getters.load_data` to \
@@ -1336,6 +1338,7 @@ value can also be provided if a different value is required.
 LookupPeriod, InflatedLevelisationFund, TotalElectricitySupplied, ExemptSupplyOutsideUK, \
 ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fields.
             revenue: float, a total revenue amount (£) for the levy.
+            scaling_factor: float, factor to scale total revenue amount (£) to reflect e.g. only domestic share.
         """
         # get latest fit values from df
         latest = (
@@ -1351,8 +1354,12 @@ ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fi
             latest.ExemptSupplyEII,
         )
 
-        if not revenue:
-            revenue = latest.InflatedLevelisationFund
+        if revenue:
+            if scaling_factor:
+                revenue = revenue * scaling_factor
+        else:
+            if scaling_factor:
+                revenue = latest.InflatedLevelisationFund * scaling_factor
 
         return cls(
             name="Feed in Tariff",

--- a/asf_levies_model/notebooks/report_scenarios_summary.py
+++ b/asf_levies_model/notebooks/report_scenarios_summary.py
@@ -30,32 +30,6 @@ from asf_levies_model.summary import (
 from asf_levies_model import config, PROJECT_DIR
 
 # %%
-# Annex 4 and initialise levies
-fileobject = download_annex_4(as_fileobject=True)
-levies = [
-    RO.from_dataframe(process_data_RO(fileobject), denominator=94_200_366),
-    AAHEDC.from_dataframe(process_data_AAHEDC(fileobject), denominator=94_200_366),
-    GGL.from_dataframe(process_data_GGL(fileobject), denominator=24_503_683),
-    WHD.from_dataframe(process_data_WHD(fileobject)),
-    ECO.from_dataframe(process_data_ECO(fileobject)),
-    FIT.from_dataframe(process_data_FIT(fileobject), revenue=689_233_317),
-]
-fileobject.close()
-
-# %%
-# Annex 9 and initialise tariffs (Other Payment method)
-fileobject = download_annex_9(as_fileobject=True)
-elec_other_payment_nil = process_tariff_elec_other_payment_nil(fileobject)
-elec_other_payment_typical = process_tariff_elec_other_payment_typical(fileobject)
-gas_other_payment_nil = process_tariff_gas_other_payment_nil(fileobject)
-gas_other_payment_typical = process_tariff_gas_other_payment_typical(fileobject)
-fileobject.close()
-
-# %%
-# Load archetypes headline data
-ofgem_archetypes_df = ofgem_archetypes_data()
-
-# %%
 # Set denominator values
 supply_elec = 94_200_366
 supply_gas = 265_197_947
@@ -71,6 +45,42 @@ denominator_values = {
 denominators = {
     key: denominator_values for key in ["ro", "aahedc", "ggl", "whd", "eco", "fit"]
 }
+
+# %%
+# Scaling factor for estimating domestic share of FIT revenue
+total_supply_elec = (
+    250_020_739  # DESNZ GB total electricity consumption - all meters (2022)
+)
+fit_scaling_factor = supply_elec / total_supply_elec
+
+# %%
+# Annex 4 and initialise levies
+fileobject = download_annex_4(as_fileobject=True)
+levies = [
+    RO.from_dataframe(process_data_RO(fileobject), denominator=94_200_366),
+    AAHEDC.from_dataframe(process_data_AAHEDC(fileobject), denominator=94_200_366),
+    GGL.from_dataframe(process_data_GGL(fileobject), denominator=24_503_683),
+    WHD.from_dataframe(process_data_WHD(fileobject)),
+    ECO.from_dataframe(process_data_ECO(fileobject)),
+    FIT.from_dataframe(
+        process_data_FIT(fileobject),
+        scaling_factor=fit_scaling_factor,
+    ),
+]
+fileobject.close()
+
+# %%
+# Annex 9 and initialise tariffs (Other Payment method)
+fileobject = download_annex_9(as_fileobject=True)
+elec_other_payment_nil = process_tariff_elec_other_payment_nil(fileobject)
+elec_other_payment_typical = process_tariff_elec_other_payment_typical(fileobject)
+gas_other_payment_nil = process_tariff_gas_other_payment_nil(fileobject)
+gas_other_payment_typical = process_tariff_gas_other_payment_typical(fileobject)
+fileobject.close()
+
+# %%
+# Load archetypes headline data
+ofgem_archetypes_df = ofgem_archetypes_data()
 
 # %%
 # Scenario 1: Status quo - Rebalance baseline to reflect denominators


### PR DESCRIPTION
This code introduces two main changes:

**1.** In `levies.py`, the `from_dataframe` class method for FIT now has a new argument called `scaling_factor`.
* If a scaling factor is provided, the revenue attribute will be updated to be:
(a) if no revenue provided, total revenue (inflated levelisation fund) multiplied by the given scaling, **or**
(b) provided revenue multiplied by the given scaling factor.
* If neither are given, behaviour is retained where the revenue attribute is set as the inflated levelisation fund.

**2.** In `report_scenarios_summary.py`, a scaling factor is implemented when instantiating the FIT levy object to scale revenue to its estimated domestic share.

For this PR, please could you:
* Check and test the if-else statement logic for processing the revenue and scaling factor arguments.
* Check the way it is implemented in `report_scenarios_summary.py` gives the expected output.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
