### PR TITLE
Add 28AD price cap period to model

### DIFF
--- a/asf_levies_model/getters/load_data.py
+++ b/asf_levies_model/getters/load_data.py
@@ -49,6 +49,122 @@ else:
     # If no data_output root has been given, just use the base PROJECT_DIR
     ARCHETYPE_DATA_ROOT = str(PROJECT_DIR) + "/"
 
+# Create 28AD Charge restriction period index
+
+_outer_idx = pd.IntervalIndex.from_tuples(
+    [
+        (pd.to_datetime("2015-04-01 00:00:00"), pd.to_datetime("2015-09-30 23:59:59")),
+        (pd.to_datetime("2015-10-01 00:00:00"), pd.to_datetime("2016-03-31 23:59:59")),
+        (pd.to_datetime("2016-04-01 00:00:00"), pd.to_datetime("2016-09-30 23:59:59")),
+        (pd.to_datetime("2016-10-01 00:00:00"), pd.to_datetime("2017-03-31 23:59:59")),
+        (pd.to_datetime("2017-04-01 00:00:00"), pd.to_datetime("2017-09-30 23:59:59")),
+        (pd.to_datetime("2017-10-01 00:00:00"), pd.to_datetime("2018-03-31 23:59:59")),
+        (pd.to_datetime("2018-04-01 00:00:00"), pd.to_datetime("2018-09-30 23:59:59")),
+        (pd.to_datetime("2018-10-01 00:00:00"), pd.to_datetime("2019-03-31 23:59:59")),
+        (pd.to_datetime("2019-01-01 00:00:00"), pd.to_datetime("2019-03-31 23:59:59")),
+        (pd.to_datetime("2019-04-01 00:00:00"), pd.to_datetime("2019-09-30 23:59:59")),
+        (pd.to_datetime("2019-10-01 00:00:00"), pd.to_datetime("2020-03-31 23:59:59")),
+        (pd.to_datetime("2020-04-01 00:00:00"), pd.to_datetime("2020-09-30 23:59:59")),
+        (pd.to_datetime("2020-10-01 00:00:00"), pd.to_datetime("2021-03-31 23:59:59")),
+        (pd.to_datetime("2021-04-01 00:00:00"), pd.to_datetime("2021-09-30 23:59:59")),
+        (pd.to_datetime("2021-10-01 00:00:00"), pd.to_datetime("2022-03-31 23:59:59")),
+        (pd.to_datetime("2022-04-01 00:00:00"), pd.to_datetime("2022-09-30 23:59:59")),
+        (pd.to_datetime("2022-10-01 00:00:00"), pd.to_datetime("2023-03-31 23:59:59")),
+        (pd.to_datetime("2022-10-01 00:00:00"), pd.to_datetime("2023-03-31 23:59:59")),
+        (pd.to_datetime("2023-04-01 00:00:00"), pd.to_datetime("2023-09-30 23:59:59")),
+        (pd.to_datetime("2023-04-01 00:00:00"), pd.to_datetime("2023-09-30 23:59:59")),
+        (pd.to_datetime("2023-10-01 00:00:00"), pd.to_datetime("2024-03-31 23:59:59")),
+        (pd.to_datetime("2023-10-01 00:00:00"), pd.to_datetime("2024-03-31 23:59:59")),
+        (pd.to_datetime("2024-04-01 00:00:00"), pd.to_datetime("2024-09-30 23:59:59")),
+        (pd.to_datetime("2024-04-01 00:00:00"), pd.to_datetime("2024-09-30 23:59:59")),
+        (pd.to_datetime("2024-10-01 00:00:00"), pd.to_datetime("2025-03-31 23:59:59")),
+        (pd.to_datetime("2024-10-01 00:00:00"), pd.to_datetime("2025-03-31 23:59:59")),
+        (pd.to_datetime("2025-04-01 00:00:00"), pd.to_datetime("2025-09-30 23:59:59")),
+        (pd.to_datetime("2025-04-01 00:00:00"), pd.to_datetime("2025-09-30 23:59:59")),
+        (pd.to_datetime("2025-10-01 00:00:00"), pd.to_datetime("2026-03-31 23:59:59")),
+        (pd.to_datetime("2025-10-01 00:00:00"), pd.to_datetime("2026-03-31 23:59:59")),
+        (pd.to_datetime("2026-04-01 00:00:00"), pd.to_datetime("2026-09-30 23:59:59")),
+        (pd.to_datetime("2026-04-01 00:00:00"), pd.to_datetime("2026-09-30 23:59:59")),
+        (pd.to_datetime("2026-10-01 00:00:00"), pd.to_datetime("2027-03-31 23:59:59")),
+        (pd.to_datetime("2026-10-01 00:00:00"), pd.to_datetime("2027-03-31 23:59:59")),
+        (pd.to_datetime("2027-04-01 00:00:00"), pd.to_datetime("2027-09-30 23:59:59")),
+        (pd.to_datetime("2027-04-01 00:00:00"), pd.to_datetime("2027-09-30 23:59:59")),
+        (pd.to_datetime("2027-10-01 00:00:00"), pd.to_datetime("2028-03-31 23:59:59")),
+        (pd.to_datetime("2027-10-01 00:00:00"), pd.to_datetime("2028-03-31 23:59:59")),
+        (pd.to_datetime("2028-04-01 00:00:00"), pd.to_datetime("2028-09-30 23:59:59")),
+        (pd.to_datetime("2028-04-01 00:00:00"), pd.to_datetime("2028-09-30 23:59:59")),
+        (pd.to_datetime("2028-10-01 00:00:00"), pd.to_datetime("2029-03-31 23:59:59")),
+        (pd.to_datetime("2028-10-01 00:00:00"), pd.to_datetime("2029-03-31 23:59:59")),
+        (pd.to_datetime("2029-04-01 00:00:00"), pd.to_datetime("2029-09-30 23:59:59")),
+        (pd.to_datetime("2029-04-01 00:00:00"), pd.to_datetime("2029-09-30 23:59:59")),
+        (pd.to_datetime("2029-10-01 00:00:00"), pd.to_datetime("2030-03-31 23:59:59")),
+        (pd.to_datetime("2029-10-01 00:00:00"), pd.to_datetime("2030-03-31 23:59:59")),
+        (pd.to_datetime("2030-04-01 00:00:00"), pd.to_datetime("2030-09-30 23:59:59")),
+        (pd.to_datetime("2030-04-01 00:00:00"), pd.to_datetime("2030-09-30 23:59:59")),
+        (pd.to_datetime("2030-10-01 00:00:00"), pd.to_datetime("2031-03-31 23:59:59")),
+    ],
+    closed="both",
+    name="28AD Charge Restriction Period 6 Month",
+)
+
+_inner_idx = pd.IntervalIndex.from_tuples(
+    [
+        (pd.to_datetime("2015-04-01 00:00:00"), pd.to_datetime("2015-09-30 23:59:59")),
+        (pd.to_datetime("2015-10-01 00:00:00"), pd.to_datetime("2016-03-31 23:59:59")),
+        (pd.to_datetime("2016-04-01 00:00:00"), pd.to_datetime("2016-09-30 23:59:59")),
+        (pd.to_datetime("2016-10-01 00:00:00"), pd.to_datetime("2017-03-31 23:59:59")),
+        (pd.to_datetime("2017-04-01 00:00:00"), pd.to_datetime("2017-09-30 23:59:59")),
+        (pd.to_datetime("2017-10-01 00:00:00"), pd.to_datetime("2018-03-31 23:59:59")),
+        (pd.to_datetime("2018-04-01 00:00:00"), pd.to_datetime("2018-09-30 23:59:59")),
+        (pd.to_datetime("2018-10-01 00:00:00"), pd.to_datetime("2019-03-31 23:59:59")),
+        (pd.to_datetime("2019-01-01 00:00:00"), pd.to_datetime("2019-03-31 23:59:59")),
+        (pd.to_datetime("2019-04-01 00:00:00"), pd.to_datetime("2019-09-30 23:59:59")),
+        (pd.to_datetime("2019-10-01 00:00:00"), pd.to_datetime("2020-03-31 23:59:59")),
+        (pd.to_datetime("2020-04-01 00:00:00"), pd.to_datetime("2020-09-30 23:59:59")),
+        (pd.to_datetime("2020-10-01 00:00:00"), pd.to_datetime("2021-03-31 23:59:59")),
+        (pd.to_datetime("2021-04-01 00:00:00"), pd.to_datetime("2021-09-30 23:59:59")),
+        (pd.to_datetime("2021-10-01 00:00:00"), pd.to_datetime("2022-03-31 23:59:59")),
+        (pd.to_datetime("2022-04-01 00:00:00"), pd.to_datetime("2022-09-30 23:59:59")),
+        (pd.to_datetime("2022-10-01 00:00:00"), pd.to_datetime("2022-12-31 23:59:59")),
+        (pd.to_datetime("2023-01-01 00:00:00"), pd.to_datetime("2023-03-31 23:59:59")),
+        (pd.to_datetime("2023-04-01 00:00:00"), pd.to_datetime("2023-06-30 23:59:59")),
+        (pd.to_datetime("2023-07-01 00:00:00"), pd.to_datetime("2023-09-30 23:59:59")),
+        (pd.to_datetime("2023-10-01 00:00:00"), pd.to_datetime("2023-12-31 23:59:59")),
+        (pd.to_datetime("2024-01-01 00:00:00"), pd.to_datetime("2024-03-31 23:59:59")),
+        (pd.to_datetime("2024-04-01 00:00:00"), pd.to_datetime("2024-06-30 23:59:59")),
+        (pd.to_datetime("2024-07-01 00:00:00"), pd.to_datetime("2024-09-30 23:59:59")),
+        (pd.to_datetime("2024-10-01 00:00:00"), pd.to_datetime("2024-12-31 23:59:59")),
+        (pd.to_datetime("2025-01-01 00:00:00"), pd.to_datetime("2025-03-31 23:59:59")),
+        (pd.to_datetime("2025-04-01 00:00:00"), pd.to_datetime("2025-06-30 23:59:59")),
+        (pd.to_datetime("2025-07-01 00:00:00"), pd.to_datetime("2025-09-30 23:59:59")),
+        (pd.to_datetime("2025-10-01 00:00:00"), pd.to_datetime("2025-12-31 23:59:59")),
+        (pd.to_datetime("2026-01-01 00:00:00"), pd.to_datetime("2026-03-31 23:59:59")),
+        (pd.to_datetime("2026-04-01 00:00:00"), pd.to_datetime("2026-06-30 23:59:59")),
+        (pd.to_datetime("2026-07-01 00:00:00"), pd.to_datetime("2026-09-30 23:59:59")),
+        (pd.to_datetime("2026-10-01 00:00:00"), pd.to_datetime("2026-12-31 23:59:59")),
+        (pd.to_datetime("2027-01-01 00:00:00"), pd.to_datetime("2027-03-31 23:59:59")),
+        (pd.to_datetime("2027-04-01 00:00:00"), pd.to_datetime("2027-06-30 23:59:59")),
+        (pd.to_datetime("2027-07-01 00:00:00"), pd.to_datetime("2027-09-30 23:59:59")),
+        (pd.to_datetime("2027-10-01 00:00:00"), pd.to_datetime("2027-12-31 23:59:59")),
+        (pd.to_datetime("2028-01-01 00:00:00"), pd.to_datetime("2028-03-31 23:59:59")),
+        (pd.to_datetime("2028-04-01 00:00:00"), pd.to_datetime("2028-06-30 23:59:59")),
+        (pd.to_datetime("2028-07-01 00:00:00"), pd.to_datetime("2028-09-30 23:59:59")),
+        (pd.to_datetime("2028-10-01 00:00:00"), pd.to_datetime("2028-12-31 23:59:59")),
+        (pd.to_datetime("2029-01-01 00:00:00"), pd.to_datetime("2029-03-31 23:59:59")),
+        (pd.to_datetime("2029-04-01 00:00:00"), pd.to_datetime("2029-06-30 23:59:59")),
+        (pd.to_datetime("2029-07-01 00:00:00"), pd.to_datetime("2029-09-30 23:59:59")),
+        (pd.to_datetime("2029-10-01 00:00:00"), pd.to_datetime("2029-12-31 23:59:59")),
+        (pd.to_datetime("2030-01-01 00:00:00"), pd.to_datetime("2030-03-31 23:59:59")),
+        (pd.to_datetime("2030-04-01 00:00:00"), pd.to_datetime("2030-06-30 23:59:59")),
+        (pd.to_datetime("2030-07-01 00:00:00"), pd.to_datetime("2030-09-30 23:59:59")),
+        (pd.to_datetime("2030-10-01 00:00:00"), pd.to_datetime("2030-12-31 23:59:59")),
+    ],
+    closed="both",
+    name="28AD Charge Restriction Period 3 Month",
+)
+
+index_28AD = pd.MultiIndex.from_arrays([_outer_idx, _inner_idx])
+
 
 # Functions for getting and processing Annex 4 data
 
@@ -260,6 +376,9 @@ def _process_data(
     data_tidy_df["UpdateDate"] = pd.to_datetime(
         data_tidy_df["UpdateDate"], format="%B %Y"
     )
+    # Add 28AD charge restriction index
+    data_tidy_df = data_tidy_df.set_index(index_28AD)
+
     return data_tidy_df
 
 
@@ -366,19 +485,6 @@ def validate_input_data(policy_data_tidy_df: pd.DataFrame, policy_data_schema: d
         print(exc)
 
 
-def _get_charging_periods(policy_df: pd.DataFrame) -> List[np.array]:
-    """Populates a list of lists containing the 28AD charge restriction periods
-    (specific to 3i New FIT methodology tab in annex 4)."""
-    row_indices = (
-        (policy_df == "28AD charge restriction period:")
-        .sum(axis=1)
-        .astype(bool)
-        .pipe(lambda df: df.index[df])[-2:]
-    )
-    periods = policy_df.loc[row_indices].dropna(axis=1, how="all").to_numpy()
-    return [periods[0][1:], periods[1][1:]]
-
-
 def _get_lookup_periods(policy_df: pd.DataFrame) -> np.array:
     """Populates a list containing lookup periods
     (specific to Table 5 in 3i New FIT methodology tab in annex 4)."""
@@ -389,15 +495,6 @@ def _get_lookup_periods(policy_df: pd.DataFrame) -> np.array:
         .pipe(lambda df: df.index[df])
     )
     return policy_df.loc[lookup_period_row_index].dropna(axis=1).to_numpy()[0][1:]
-
-
-def _check_periods(charge_period_1: list, charge_period_2: list, lookup_period: list):
-    """Checks if number of charge periods and lookup periods are equal."""
-    if len(charge_period_1) == len(charge_period_2) == len(lookup_period):
-        print(f"Number of entries: {len(charge_period_1)}")
-        return True
-    else:
-        return False
 
 
 def _extract_FIT_policy_data(
@@ -425,15 +522,8 @@ def process_data_FIT(fileobject: Optional[BytesIO] = None) -> pd.DataFrame:
     """Extracts and transforms data from corresponding New FIT tab in annex 4 into tidy format."""
     # Create dataframe of raw FIT data from spreadsheet tab
     FIT_df = _get_raw_dataframe_annex4("New FIT", fileobject)
-    # Create list of 28AD charge restriction periods (Table 5)
-    charge_periods = _get_charging_periods(FIT_df)
-    charge_periods_1 = charge_periods[0]
-    charge_periods_2 = charge_periods[1]
     # Create list of lookup periods (Table 5)
     lookup_periods = _get_lookup_periods(FIT_df)
-    # Check charge restriction periods and lookup periods match
-    if not _check_periods(charge_periods_1, charge_periods_2, lookup_periods):
-        raise ValueError("Number of time periods do not match!")
     # Create a list for each parameter of interest
     parameter_names = [
         "Inflated Levelisation fund (£)",
@@ -452,8 +542,6 @@ def process_data_FIT(fileobject: Optional[BytesIO] = None) -> pd.DataFrame:
     # Create dataframe containing FIT data in tidy format
     data_tidy_df = pd.concat(
         [
-            pd.Series(charge_periods_1, name="ChargeRestrictionPeriod1"),
-            pd.Series(charge_periods_2, name="ChargeRestrictionPeriod2"),
             pd.Series(lookup_periods, name="LookupPeriod"),
         ]
         + [
@@ -462,14 +550,20 @@ def process_data_FIT(fileobject: Optional[BytesIO] = None) -> pd.DataFrame:
         ],
         axis=1,
     )
-    data_tidy_df["ChargeRestrictionPeriod2_start"] = pd.to_datetime(
-        data_tidy_df["ChargeRestrictionPeriod2"].str.split("\s?-\s?", expand=True)[0],
-        format="%B %Y",
+
+    # Add 28AD index
+    data_tidy_df = data_tidy_df.set_index(index_28AD[3:])
+    # backfill 3 missing rows to match other levies
+    data_tidy_df = pd.concat(
+        [
+            pd.DataFrame(
+                np.full((3, len(data_tidy_df.columns)), np.nan),
+                columns=data_tidy_df.columns,
+            ).set_index(index_28AD[:3]),
+            data_tidy_df,
+        ]
     )
-    data_tidy_df["ChargeRestrictionPeriod2_end"] = pd.to_datetime(
-        data_tidy_df["ChargeRestrictionPeriod2"].str.split("\s?-\s?", expand=True)[1],
-        format="%B %Y",
-    )
+
     return data_tidy_df
 
 

--- a/asf_levies_model/getters/load_data.py
+++ b/asf_levies_model/getters/load_data.py
@@ -754,21 +754,49 @@ def _tidy_tariff_table(
     pd.DataFrame
         Dataframing containing tariff component values for one fuel type-payment method in tidy format.
     """
-    # Tidy input data
-    tidy_df = input_df.melt(
-        id_vars=type_of_consumption, var_name="28AD_Charge_Restriction_Period"
+    # Transpose table to put 28ad charging period in the index
+    df = input_df.set_index(type_of_consumption).transpose().reset_index()
+    # Get starting period of the table
+    starting_period = pd.to_datetime(df.loc[0, "index"].split("-")[0])
+    # Get index starting point
+    try:
+        start_index = (
+            index_28AD.map(lambda idx: True if starting_period in idx[1] else False)
+            .to_numpy()
+            .nonzero()[0][0]
+        )
+    except IndexError:
+        raise IndexError("Could not match tariff start date with 28AD index.")
+    # set multi index
+    # Remove Jan 2019 record - this isn't used for tariffs.
+    drop_idx = (
+        index_28AD.map(
+            lambda idx: True if pd.to_datetime("2019-01") in idx[1] else False
+        )
+        .to_numpy()
+        .nonzero()[0][1]
     )
-    # Add start and end dates
-    with warnings.catch_warnings():
-        # Suppress warning for datetime parsing each element individually.
-        # Dates in this table are a mess and this is desired behaviour.
-        warnings.simplefilter("ignore")
-        tidy_df["28AD_Charge_Restriction_Period_start"] = pd.to_datetime(
-            tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[0]
+    # Add index to table - dropping unneeded row and limiting to relevant period.
+    df = df.set_index(
+        index_28AD.drop(index_28AD[drop_idx])[start_index : start_index + df.shape[0]]
+    )
+
+    tidy_df = (
+        df.drop(columns="index")
+        .reset_index()
+        .melt(
+            id_vars=[
+                "28AD Charge Restriction Period 6 Month",
+                "28AD Charge Restriction Period 3 Month",
+            ]
         )
-        tidy_df["28AD_Charge_Restriction_Period_end"] = pd.to_datetime(
-            tidy_df["28AD_Charge_Restriction_Period"].str.split("-", expand=True)[1]
+        .set_index(
+            [
+                "28AD Charge Restriction Period 6 Month",
+                "28AD Charge Restriction Period 3 Month",
+            ]
         )
+    )
 
     return tidy_df
 

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -694,8 +694,7 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
             latest_index = (
                 df[["TariffCurrentYear", "TariffPreviousYear"]]
                 .isna()
-                .apply(
-                    lambda row: row["TariffCurrentYear"] & row["TariffPreviousYear"],
+                .all(axis=1)
                     axis=1,
                 )
                 .to_numpy()

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -388,7 +388,7 @@ class Levy:
         ]
 
         return repr(
-            f'Levy(name="{self.name}", short_name="{self.short_name}", {", ".join([f"{attr}={getattr(self, attr)}" for attr in non_zero])})'
+            f'Levy(name="{self.name}", short_name="{self.short_name}", price_cap_period="{repr(self.price_cap_period)}", {", ".join([f"{attr}={getattr(self, attr)}" for attr in non_zero])})'
         )
 
     def __str__(self):

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -695,8 +695,6 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
                 df[["TariffCurrentYear", "TariffPreviousYear"]]
                 .isna()
                 .all(axis=1)
-                    axis=1,
-                )
                 .to_numpy()
                 .nonzero()[0][0]
             )

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -510,10 +510,7 @@ BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fi
             latest_index = (
                 df[["ObligationLevel", "BuyOutPriceSchemeYear"]]
                 .isna()
-                .apply(
-                    lambda row: row["ObligationLevel"] & row["BuyOutPriceSchemeYear"],
-                    axis=1,
-                )
+                .all(axis=1)
                 .to_numpy()
                 .nonzero()[0][0]
             )

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -2,10 +2,10 @@ import copy
 import numpy as np
 import pandas as pd
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 import warnings
 
-from asf_levies_model.utils.utils import _generate_docstring
+from asf_levies_model.utils.utils import _generate_docstring, PriceCapPeriod
 
 
 class Levy:
@@ -35,6 +35,7 @@ class Levy:
             gas_fixed_rate: float [0, inf) the gas fixed rate for a levy.
             general_taxation: float [0, inf) the levy revenue passed to general taxation.
             revenue: float [0, inf) the total levy revenue.
+            price_cap_period: Interval indicating the price cap period the levy covers.
     """
 
     def __init__(
@@ -54,6 +55,7 @@ class Levy:
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         """Initializes the instance based on provided levy parameters.
 
@@ -73,6 +75,7 @@ class Levy:
             gas_fixed_rate: Rate to calculate gas fixed cost (per customer or meter).
             general_taxation: Revenue abstracted to general taxation (absolute value).
             revenue: Total levy revenue (absolute value).
+            price_cap_period: Energy price cap period covered by the levy instance.
         """
         self.name = name
         self.short_name = short_name
@@ -97,6 +100,9 @@ class Levy:
 
         # revenue
         self.revenue = revenue
+
+        # price cap period
+        self.price_cap_period = price_cap_period
 
     def calculate_levy(
         self,
@@ -433,6 +439,7 @@ class RO(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         UpdateDate: datetime,
         SchemeYear: str,
         obligation_level: float,
@@ -456,6 +463,7 @@ class RO(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.UpdateDate = UpdateDate
         self.SchemeYear = SchemeYear
@@ -527,6 +535,10 @@ BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fi
             else:
                 df = df.loc[mask].iloc[0]
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         ro_levy = cls.calculate_renewable_obligation_rate(
             df.ObligationLevel,
             df.BuyOutPriceSchemeYear,
@@ -552,6 +564,7 @@ BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fi
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             UpdateDate=df.UpdateDate,
             SchemeYear=df.SchemeYear,
             obligation_level=df.ObligationLevel,
@@ -615,6 +628,7 @@ class AAHEDC(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         UpdateDate: datetime,
         SchemeYear: str,
         TariffCurrentYear: float,
@@ -637,6 +651,7 @@ class AAHEDC(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.UpdateDate = UpdateDate
         self.SchemeYear = SchemeYear
@@ -715,6 +730,10 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
             df.TariffCurrentYear, aahedc_tariff_forecast
         )
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         if not revenue:
             revenue = aahedc_levy * denominator
 
@@ -734,6 +753,7 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             UpdateDate=df.UpdateDate,
             SchemeYear=df.SchemeYear,
             TariffCurrentYear=df.TariffCurrentYear,
@@ -799,6 +819,7 @@ class GGL(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         UpdateDate: datetime,
         SchemeYear: str,
         LevyRate: float,
@@ -820,6 +841,7 @@ class GGL(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.UpdateDate = UpdateDate
         self.SchemeYear = SchemeYear
@@ -882,6 +904,10 @@ price cap period of interest.
 
         ggl_levy = cls.calculate_ggl_rate(df.LevyRate, df.BackdatedLevyRate)
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         if not revenue:
             revenue = ggl_levy * denominator
 
@@ -901,6 +927,7 @@ price cap period of interest.
             gas_fixed_rate=ggl_levy,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             UpdateDate=df.UpdateDate,
             SchemeYear=df.SchemeYear,
             LevyRate=df.LevyRate,
@@ -962,6 +989,7 @@ class WHD(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         UpdateDate: datetime,
         SchemeYear: str,
         TargetSpendingForSchemeYear: float,
@@ -986,6 +1014,7 @@ class WHD(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.UpdateDate = UpdateDate
         self.SchemeYear = SchemeYear
@@ -1063,6 +1092,10 @@ NoncoreSpending, ObligatedSuppliersCustomerBase, CompulsorySupplierFractionOfCor
             df.CompulsorySupplierFractionOfCoreGroup,
         )
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         if not revenue:
             revenue = df.TargetSpendingForSchemeYear
 
@@ -1089,6 +1122,7 @@ NoncoreSpending, ObligatedSuppliersCustomerBase, CompulsorySupplierFractionOfCor
             gas_fixed_rate=whd_levy,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             UpdateDate=df.UpdateDate,
             SchemeYear=df.SchemeYear,
             TargetSpendingForSchemeYear=df.TargetSpendingForSchemeYear,
@@ -1175,6 +1209,7 @@ class ECO(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         UpdateDate: datetime,
         SchemeYear: str,
         AnnualisedCostECO4Gas: float,
@@ -1204,6 +1239,7 @@ class ECO(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.UpdateDate = UpdateDate
         self.SchemeYear = SchemeYear
@@ -1291,6 +1327,10 @@ ObligatedSupplierVolumeElectricity, fields.
             df.ObligatedSupplierVolumeElectricity,
         )
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         if not revenue:
             revenue = (
                 (
@@ -1327,6 +1367,7 @@ ObligatedSupplierVolumeElectricity, fields.
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             UpdateDate=df.UpdateDate,
             SchemeYear=df.SchemeYear,
             AnnualisedCostECO4Gas=df.AnnualisedCostECO4Gas,
@@ -1417,6 +1458,7 @@ class FIT(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
         LookupPeriod: str,
         InflatedLevelisationFund: float,
         TotalElectricitySupplied: float,
@@ -1439,6 +1481,7 @@ class FIT(Levy):
             gas_fixed_rate,
             general_taxation,
             revenue,
+            price_cap_period,
         )
         self.LookupPeriod = LookupPeriod
         self.InflatedLevelisationFund = InflatedLevelisationFund
@@ -1506,6 +1549,10 @@ ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fi
             df.ExemptSupplyEII,
         )
 
+        price_cap_period = PriceCapPeriod(
+            left=df.name[1].left, right=df.name[1].right, closed="both"
+        )
+
         if not revenue:
             revenue = df.InflatedLevelisationFund * scaling_factor
         else:
@@ -1527,6 +1574,7 @@ ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fi
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
+            price_cap_period=price_cap_period,
             LookupPeriod=df.LookupPeriod,
             InflatedLevelisationFund=df.InflatedLevelisationFund,
             TotalElectricitySupplied=df.TotalElectricitySupplied,

--- a/asf_levies_model/levies.py
+++ b/asf_levies_model/levies.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from datetime import datetime
 from typing import Optional
+import warnings
 
 from asf_levies_model.utils.utils import _generate_docstring
 
@@ -465,21 +466,30 @@ class RO(Levy):
 
     @classmethod
     def from_dataframe(
-        cls, df: pd.DataFrame, revenue: float = None, denominator: float = None
+        cls,
+        df: pd.DataFrame,
+        revenue: float = None,
+        denominator: float = None,
+        price_cap: str = "LATEST",
     ) -> "RO":
         """Create RO levy instance from dataframe input.
 
         Uses the `process_data_RO()` output from `asf_levies_model.getters.load_data` to \
 initialise a RO levy object at present values.
 
-        As RO doesn't have a stated revenue or scheme cost, revenue must either be provided,\
+        As RO doesn't have a stated revenue or scheme cost, revenue must either be provided, \
 or a denominator in MWh given to calculate it from the levy value (£/MWh).
+
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
 
         Args:
             df: a dataframe with UpdateDate, SchemeYear, obligation_level,\
 BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fields.
             revenue: float, a total revenue amount (£) for the levy.
             denominator: float, a total supply amount (MWh) to calculate the revenue.
+            price_cap: str, price cap period to use; default: LATEST.
 
         Raises:
             ValueError: revenue or denominator must be provided.
@@ -487,17 +497,40 @@ BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fi
         if (revenue is None) & (denominator is None):
             raise ValueError("Please provide either revenue or denominator.")
 
-        # get latest ro values from df
-        latest = (
-            df.loc[lambda df: df["ObligationLevel"].notna()]
-            .sort_values("UpdateDate", ascending=False)
-            .iloc[0]
-        )
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = (
+                df[["ObligationLevel", "BuyOutPriceSchemeYear"]]
+                .isna()
+                .apply(
+                    lambda row: row["ObligationLevel"] & row["BuyOutPriceSchemeYear"],
+                    axis=1,
+                )
+                .to_numpy()
+                .nonzero()[0][0]
+            )
+            df = df.iloc[latest_index - 1]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
 
         ro_levy = cls.calculate_renewable_obligation_rate(
-            latest.ObligationLevel,
-            latest.BuyOutPriceSchemeYear,
-            latest.BuyOutPricePreviousYear,
+            df.ObligationLevel,
+            df.BuyOutPriceSchemeYear,
+            df.BuyOutPricePreviousYear,
         )
 
         if not revenue:
@@ -519,12 +552,12 @@ BuyOutPriceSchemeYear, BuyOutPricePreviousYear, ForecastAnnualRPIPreviousYear fi
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
-            UpdateDate=latest.UpdateDate,
-            SchemeYear=latest.SchemeYear,
-            obligation_level=latest.ObligationLevel,
-            BuyOutPriceSchemeYear=latest.BuyOutPriceSchemeYear,
-            BuyOutPricePreviousYear=latest.BuyOutPricePreviousYear,
-            ForecastAnnualRPIPreviousYear=latest.ForecastAnnualRPIPreviousYear,
+            UpdateDate=df.UpdateDate,
+            SchemeYear=df.SchemeYear,
+            obligation_level=df.ObligationLevel,
+            BuyOutPriceSchemeYear=df.BuyOutPriceSchemeYear,
+            BuyOutPricePreviousYear=df.BuyOutPricePreviousYear,
+            ForecastAnnualRPIPreviousYear=df.ForecastAnnualRPIPreviousYear,
         )
 
     @staticmethod
@@ -613,7 +646,11 @@ class AAHEDC(Levy):
 
     @classmethod
     def from_dataframe(
-        cls, df: pd.DataFrame, revenue: float = None, denominator: float = None
+        cls,
+        df: pd.DataFrame,
+        revenue: float = None,
+        denominator: float = None,
+        price_cap: str = "LATEST",
     ) -> "AAHEDC":
         """Create AAHEDC levy instance from dataframe input.
 
@@ -623,11 +660,16 @@ initialise an AAHEDC levy object at present values.
         As AAHEDC doesn't have a stated revenue or scheme cost, revenue must either be provided,\
 or a denominator in MWh given to calculate it from the levy value (£/MWh at GSP).
 
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
+
         Args:
             df: a dataframe with UpdateDate, SchemeYear, TariffCurrentYear,\
 TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
             revenue: float, a total revenue amount (£) for the levy.
             denominator: float, a total supply amount (MWh) to calculate the revenue.
+            price_cap: str, price cap period to use; default: LATEST.
 
         Raises:
             ValueError: revenue or denominator must be provided.
@@ -635,30 +677,42 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
         if (revenue is None) & (denominator is None):
             raise ValueError("Please provide either revenue or denominator.")
 
-        # get latest aahedc values from df
-        latest = (
-            df.assign(
-                tariff=lambda df: df.apply(
-                    lambda x: (
-                        x["TariffCurrentYear"]
-                        if not np.isnan(x["TariffCurrentYear"])
-                        else x["TariffPreviousYear"]
-                    ),
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = (
+                df[["TariffCurrentYear", "TariffPreviousYear"]]
+                .isna()
+                .apply(
+                    lambda row: row["TariffCurrentYear"] & row["TariffPreviousYear"],
                     axis=1,
                 )
+                .to_numpy()
+                .nonzero()[0][0]
             )
-            .loc[lambda df: df["tariff"].notna()]
-            .drop(columns="tariff")
-            .sort_values("UpdateDate", ascending=False)
-            .iloc[0]
-        )
+            df = df.iloc[latest_index - 1]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
 
         aahedc_tariff_forecast = cls.calculate_aahedc_tariff_forecast(
-            latest.TariffPreviousYear, latest.ForecastAnnualRPIPreviousYear
+            df.TariffPreviousYear, df.ForecastAnnualRPIPreviousYear
         )
 
         aahedc_levy = cls.calculate_aahedc_rate(
-            latest.TariffCurrentYear, aahedc_tariff_forecast
+            df.TariffCurrentYear, aahedc_tariff_forecast
         )
 
         if not revenue:
@@ -680,11 +734,11 @@ TariffPreviousYear, ForecastAnnualRPIPreviousYear fields.
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
-            UpdateDate=latest.UpdateDate,
-            SchemeYear=latest.SchemeYear,
-            TariffCurrentYear=latest.TariffCurrentYear,
-            TariffPreviousYear=latest.TariffPreviousYear,
-            ForecastAnnualRPIPreviousYear=latest.ForecastAnnualRPIPreviousYear,
+            UpdateDate=df.UpdateDate,
+            SchemeYear=df.SchemeYear,
+            TariffCurrentYear=df.TariffCurrentYear,
+            TariffPreviousYear=df.TariffPreviousYear,
+            ForecastAnnualRPIPreviousYear=df.ForecastAnnualRPIPreviousYear,
         )
 
     @staticmethod
@@ -774,7 +828,11 @@ class GGL(Levy):
 
     @classmethod
     def from_dataframe(
-        cls, df: pd.DataFrame, revenue: float = None, denominator: float = None
+        cls,
+        df: pd.DataFrame,
+        revenue: float = None,
+        denominator: float = None,
+        price_cap: str = "LATEST",
     ) -> "GGL":
         """Create GGL levy instance from dataframe input.
 
@@ -784,10 +842,15 @@ initialise a GGL levy object at present values.
         As GGL doesn't have a stated revenue or scheme cost, revenue must either be provided,\
 or a denominator (number of meters) given to calculate it from the levy value (£/meter).
 
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
+
         Args:
             df: a dataframe with UpdateDate, SchemeYear, LevyRate, BackdatedLevyRate fields.
             revenue: float, a total revenue amount (£) for the levy.
             denominator: float, a total number of meters (customers) to calculate the revenue.
+            price_cap: str, price cap period to use; default: LATEST.
 
         Raises:
             ValueError: revenue or denominator must be provided.
@@ -795,14 +858,29 @@ or a denominator (number of meters) given to calculate it from the levy value (�
         if (revenue is None) & (denominator is None):
             raise ValueError("Please provide either revenue or denominator.")
 
-        # get latest ggl values from df
-        latest = (
-            df.loc[lambda df: df["LevyRate"].notna()]
-            .sort_values("UpdateDate", ascending=False)
-            .iloc[0]
-        )
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = df["LevyRate"].notna().to_numpy().nonzero()[0].max()
 
-        ggl_levy = cls.calculate_ggl_rate(latest.LevyRate, latest.BackdatedLevyRate)
+            df = df.iloc[latest_index]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
+
+        ggl_levy = cls.calculate_ggl_rate(df.LevyRate, df.BackdatedLevyRate)
 
         if not revenue:
             revenue = ggl_levy * denominator
@@ -823,10 +901,10 @@ or a denominator (number of meters) given to calculate it from the levy value (�
             gas_fixed_rate=ggl_levy,
             general_taxation=0,
             revenue=revenue,
-            UpdateDate=latest.UpdateDate,
-            SchemeYear=latest.SchemeYear,
-            LevyRate=latest.LevyRate,
-            BackdatedLevyRate=latest.BackdatedLevyRate,
+            UpdateDate=df.UpdateDate,
+            SchemeYear=df.SchemeYear,
+            LevyRate=df.LevyRate,
+            BackdatedLevyRate=df.BackdatedLevyRate,
         )
 
     @staticmethod
@@ -920,7 +998,14 @@ class WHD(Levy):
         )
 
     @classmethod
-    def from_dataframe(cls, df, revenue=None, customers_gas=None, customers_elec=None):
+    def from_dataframe(
+        cls,
+        df,
+        revenue=None,
+        customers_gas=None,
+        customers_elec=None,
+        price_cap: str = "LATEST",
+    ):
         """Create WHD levy instance from dataframe input.
 
         Uses the `process_data_WHD()` output from `asf_levies_model.getters.load_data` to \
@@ -933,30 +1018,53 @@ value can also be provided if a different value is required.
 the ofgem spreadsheet doesn't provide sufficient information to calculate the effective gas and electric \
 shares. If customers_gas and customers_elec are provided the levy gets share information for the status quo levy.
 
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
+
         Args:
             df: a dataframe with UpdateDate, SchemeYear, TargetSpendingForSchemeYear, CoreSpending, \
 NoncoreSpending, ObligatedSuppliersCustomerBase, CompulsorySupplierFractionOfCoreGroup fields.
             revenue: float, a total revenue amount (£) for the levy.
             customers_gas: int [0, inf) annual gas customers (customer or meter count).
             customers_elec: int [0, inf) annual electricity customers (customer or meter count).
+            price_cap: str, price cap period to use; default: LATEST.
         """
         # get latest whd values from df
-        latest = (
-            df.loc[lambda df: df["TargetSpendingForSchemeYear"].notna()]
-            .sort_values("UpdateDate", ascending=False)
-            .iloc[0]
-        )
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = (
+                df["TargetSpendingForSchemeYear"].notna().to_numpy().nonzero()[0].max()
+            )
+
+            df = df.iloc[latest_index]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
 
         whd_levy = cls.calculate_whd_rate(
-            latest.TargetSpendingForSchemeYear,
-            latest.CoreSpending,
-            latest.NoncoreSpending,
-            latest.ObligatedSuppliersCustomerBase,
-            latest.CompulsorySupplierFractionOfCoreGroup,
+            df.TargetSpendingForSchemeYear,
+            df.CoreSpending,
+            df.NoncoreSpending,
+            df.ObligatedSuppliersCustomerBase,
+            df.CompulsorySupplierFractionOfCoreGroup,
         )
 
         if not revenue:
-            revenue = latest.TargetSpendingForSchemeYear
+            revenue = df.TargetSpendingForSchemeYear
 
         if customers_gas and customers_elec:
             gas_weight = customers_gas / (customers_gas + customers_elec)
@@ -981,13 +1089,13 @@ NoncoreSpending, ObligatedSuppliersCustomerBase, CompulsorySupplierFractionOfCor
             gas_fixed_rate=whd_levy,
             general_taxation=0,
             revenue=revenue,
-            UpdateDate=latest.UpdateDate,
-            SchemeYear=latest.SchemeYear,
-            TargetSpendingForSchemeYear=latest.TargetSpendingForSchemeYear,
-            CoreSpending=latest.CoreSpending,
-            NoncoreSpending=latest.NoncoreSpending,
-            ObligatedSuppliersCustomerBase=latest.ObligatedSuppliersCustomerBase,
-            CompulsorySupplierFractionOfCoreGroup=latest.CompulsorySupplierFractionOfCoreGroup,
+            UpdateDate=df.UpdateDate,
+            SchemeYear=df.SchemeYear,
+            TargetSpendingForSchemeYear=df.TargetSpendingForSchemeYear,
+            CoreSpending=df.CoreSpending,
+            NoncoreSpending=df.NoncoreSpending,
+            ObligatedSuppliersCustomerBase=df.ObligatedSuppliersCustomerBase,
+            CompulsorySupplierFractionOfCoreGroup=df.CompulsorySupplierFractionOfCoreGroup,
         )
 
     @staticmethod
@@ -1115,7 +1223,9 @@ class ECO(Levy):
         self.ObligatedSupplierVolumeElectricity = ObligatedSupplierVolumeElectricity
 
     @classmethod
-    def from_dataframe(cls, df: pd.DataFrame, revenue: float = None) -> "ECO":
+    def from_dataframe(
+        cls, df: pd.DataFrame, revenue: float = None, price_cap: str = "LATEST"
+    ) -> "ECO":
         """Create ECO levy instance from dataframe input.
 
         Uses the `process_data_ECO()` output from `asf_levies_model.getters.load_data` to \
@@ -1123,6 +1233,10 @@ initialise an ECO levy object at present values.
 
         As ECO has stated scheme costs, these are used by default as the revenue, however a revenue \
 value can also be provided if a different value is required.
+
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
 
         Args:
             df: a dataframe with UpdateDate, SchemeYear, AnnualisedCostECO4Gas, \
@@ -1132,49 +1246,68 @@ FullyObligatedShareOfObligatedSupplierSupplyGas, \
 FullyObligatedShareOfObligatedSupplierSupplyElectricity, ObligatedSupplierVolumeGas, \
 ObligatedSupplierVolumeElectricity, fields.
             revenue: float, a total revenue amount (£) for the levy.
+            price_cap: str, price cap period to use; default: LATEST.
         """
         # get latest eco values from df
-        latest = (
-            df.loc[lambda df: df["AnnualisedCostECO4Gas"].notna()]
-            .sort_values("UpdateDate", ascending=False)
-            .iloc[0]
-        )
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = (
+                df["AnnualisedCostECO4Gas"].notna().to_numpy().nonzero()[0].max()
+            )
+
+            df = df.iloc[latest_index]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
 
         eco_levy_gas = cls.calculate_eco_rate(
-            latest.AnnualisedCostECO4Gas,
-            latest.AnnualisedCostGBISGas,
-            latest.GDPDeflatorToCurrentPricesECO4,
-            latest.GDPDeflatorToCurrentPricesGBIS,
-            latest.FullyObligatedShareOfObligatedSupplierSupplyGas,
-            latest.ObligatedSupplierVolumeGas,
+            df.AnnualisedCostECO4Gas,
+            df.AnnualisedCostGBISGas,
+            df.GDPDeflatorToCurrentPricesECO4,
+            df.GDPDeflatorToCurrentPricesGBIS,
+            df.FullyObligatedShareOfObligatedSupplierSupplyGas,
+            df.ObligatedSupplierVolumeGas,
         )
 
         eco_levy_elec = cls.calculate_eco_rate(
-            latest.AnnualisedCostECO4Electricity,
-            latest.AnnualisedCostGBISElectricity,
-            latest.GDPDeflatorToCurrentPricesECO4,
-            latest.GDPDeflatorToCurrentPricesGBIS,
-            latest.FullyObligatedShareOfObligatedSupplierSupplyElectricity,
-            latest.ObligatedSupplierVolumeElectricity,
+            df.AnnualisedCostECO4Electricity,
+            df.AnnualisedCostGBISElectricity,
+            df.GDPDeflatorToCurrentPricesECO4,
+            df.GDPDeflatorToCurrentPricesGBIS,
+            df.FullyObligatedShareOfObligatedSupplierSupplyElectricity,
+            df.ObligatedSupplierVolumeElectricity,
         )
 
         if not revenue:
             revenue = (
                 (
-                    latest.AnnualisedCostECO4Gas
-                    * (1 + latest.GDPDeflatorToCurrentPricesECO4 / 100)
+                    df.AnnualisedCostECO4Gas
+                    * (1 + df.GDPDeflatorToCurrentPricesECO4 / 100)
                 )
                 + (
-                    latest.AnnualisedCostECO4Electricity
-                    * (1 + latest.GDPDeflatorToCurrentPricesECO4 / 100)
+                    df.AnnualisedCostECO4Electricity
+                    * (1 + df.GDPDeflatorToCurrentPricesECO4 / 100)
                 )
                 + (
-                    latest.AnnualisedCostGBISGas
-                    * (1 + latest.GDPDeflatorToCurrentPricesGBIS / 100)
+                    df.AnnualisedCostGBISGas
+                    * (1 + df.GDPDeflatorToCurrentPricesGBIS / 100)
                 )
                 + (
-                    latest.AnnualisedCostGBISElectricity
-                    * (1 + latest.GDPDeflatorToCurrentPricesGBIS / 100)
+                    df.AnnualisedCostGBISElectricity
+                    * (1 + df.GDPDeflatorToCurrentPricesGBIS / 100)
                 )
             )
 
@@ -1194,18 +1327,18 @@ ObligatedSupplierVolumeElectricity, fields.
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
-            UpdateDate=latest.UpdateDate,
-            SchemeYear=latest.SchemeYear,
-            AnnualisedCostECO4Gas=latest.AnnualisedCostECO4Gas,
-            AnnualisedCostECO4Electricity=latest.AnnualisedCostECO4Electricity,
-            AnnualisedCostGBISGas=latest.AnnualisedCostGBISGas,
-            AnnualisedCostGBISElectricity=latest.AnnualisedCostGBISElectricity,
-            GDPDeflatorToCurrentPricesECO4=latest.GDPDeflatorToCurrentPricesECO4,
-            GDPDeflatorToCurrentPricesGBIS=latest.GDPDeflatorToCurrentPricesGBIS,
-            FullyObligatedShareOfObligatedSupplierSupplyGas=latest.FullyObligatedShareOfObligatedSupplierSupplyGas,
-            FullyObligatedShareOfObligatedSupplierSupplyElectricity=latest.FullyObligatedShareOfObligatedSupplierSupplyElectricity,
-            ObligatedSupplierVolumeGas=latest.ObligatedSupplierVolumeGas,
-            ObligatedSupplierVolumeElectricity=latest.ObligatedSupplierVolumeElectricity,
+            UpdateDate=df.UpdateDate,
+            SchemeYear=df.SchemeYear,
+            AnnualisedCostECO4Gas=df.AnnualisedCostECO4Gas,
+            AnnualisedCostECO4Electricity=df.AnnualisedCostECO4Electricity,
+            AnnualisedCostGBISGas=df.AnnualisedCostGBISGas,
+            AnnualisedCostGBISElectricity=df.AnnualisedCostGBISElectricity,
+            GDPDeflatorToCurrentPricesECO4=df.GDPDeflatorToCurrentPricesECO4,
+            GDPDeflatorToCurrentPricesGBIS=df.GDPDeflatorToCurrentPricesGBIS,
+            FullyObligatedShareOfObligatedSupplierSupplyGas=df.FullyObligatedShareOfObligatedSupplierSupplyGas,
+            FullyObligatedShareOfObligatedSupplierSupplyElectricity=df.FullyObligatedShareOfObligatedSupplierSupplyElectricity,
+            ObligatedSupplierVolumeGas=df.ObligatedSupplierVolumeGas,
+            ObligatedSupplierVolumeElectricity=df.ObligatedSupplierVolumeElectricity,
         )
 
     @staticmethod
@@ -1249,9 +1382,7 @@ class FIT(Levy):
     __doc__ += (
         Levy.__doc__.split("\n", maxsplit=4)[4]
         + """\
-    ChargeRestrictionPeriod1: str, 28AD charge restriction period.
-        ChargeRestrictionPeriod2: str, 28AD charge restriction period.
-        LookupPeriod: str, year winter/summer lookup.
+    LookupPeriod: str, year winter/summer lookup.
         InflatedLevelisationFund: float, inflated Levelisation fund (£).
         TotalElectricitySupplied: float, total Electricity supplied (MWh).
         ExemptSupplyOutsideUK: float, exempt supply for renewable electricity from outside the UK (MWh).
@@ -1262,9 +1393,7 @@ class FIT(Levy):
     @_generate_docstring(
         Levy.__init__.__doc__,
         [
-            "    ChargeRestrictionPeriod1: 28AD charge restriction period.",
-            "            ChargeRestrictionPeriod2: 28AD charge restriction period.",
-            "            LookupPeriod: year winter/summer lookup.",
+            "    LookupPeriod: year winter/summer lookup.",
             "            InflatedLevelisationFund: inflated Levelisation fund (£).",
             "            TotalElectricitySupplied: total Electricity supplied (MWh).",
             "            ExemptSupplyOutsideUK: exempt supply for renewable electricity from outside the UK (MWh).",
@@ -1288,8 +1417,6 @@ class FIT(Levy):
         gas_fixed_rate: float,
         general_taxation: float,
         revenue: float,
-        ChargeRestrictionPeriod1: str,
-        ChargeRestrictionPeriod2: str,
         LookupPeriod: str,
         InflatedLevelisationFund: float,
         TotalElectricitySupplied: float,
@@ -1313,8 +1440,6 @@ class FIT(Levy):
             general_taxation,
             revenue,
         )
-        self.ChargeRestrictionPeriod1 = ChargeRestrictionPeriod1
-        self.ChargeRestrictionPeriod2 = ChargeRestrictionPeriod2
         self.LookupPeriod = LookupPeriod
         self.InflatedLevelisationFund = InflatedLevelisationFund
         self.TotalElectricitySupplied = TotalElectricitySupplied
@@ -1323,7 +1448,11 @@ class FIT(Levy):
 
     @classmethod
     def from_dataframe(
-        cls, df: pd.DataFrame, revenue: float = None, scaling_factor: float = 1.0
+        cls,
+        df: pd.DataFrame,
+        revenue: float = None,
+        scaling_factor: float = 1.0,
+        price_cap: str = "LATEST",
     ) -> "FIT":
         """Create FIT levy instance from dataframe input.
 
@@ -1333,29 +1462,52 @@ initialise a FIT levy object at present values.
         As FIT has a stated scheme cost, this is used by default as the revenue, however a revenue \
 value can also be provided if a different value is required.
 
+        price_cap can be specified to use values for a specific price cap. The default is latest. \
+To specify a specific price cap period supply a date in the form `YYYY-MM-DD` that falls within the \
+price cap period of interest.
+
         Args:
             df: a dataframe with ChargeRestrictionPeriod1, ChargeRestrictionPeriod2, \
 LookupPeriod, InflatedLevelisationFund, TotalElectricitySupplied, ExemptSupplyOutsideUK, \
 ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fields.
             revenue: float, a total revenue amount (£) for the levy.
             scaling_factor: float, factor to scale total revenue amount (£) to reflect e.g. only domestic share.
+            price_cap: str, price cap period to use; default: LATEST.
         """
         # get latest fit values from df
-        latest = (
-            df.loc[lambda df: df["TotalElectricitySupplied"].notna()]
-            .sort_values("ChargeRestrictionPeriod2_start", ascending=False)
-            .iloc[0]
-        )
+        if price_cap == "LATEST":
+            # Get first index where data is not captured
+            latest_index = (
+                df["TotalElectricitySupplied"].notna().to_numpy().nonzero()[0].max()
+            )
+
+            df = df.iloc[latest_index]
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            mask = df.index.map(
+                lambda row: True if price_cap_date in row[1] else False
+            ).to_numpy()
+            if mask.sum() == 0:
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            elif mask.sum() > 1:
+                # Use most recent matching period
+                df = df.loc[mask].iloc[-1]
+                warnings.warn(
+                    f"Multiple price cap periods returned, using price cap period {df.name[1].left.strftime('%Y-%m-%d')} to {df.name[1].right.strftime('%Y-%m-%d')}"
+                )
+            else:
+                df = df.loc[mask].iloc[0]
 
         fit_levy = cls.calculate_feed_in_tariff_rate(
-            latest.InflatedLevelisationFund,
-            latest.TotalElectricitySupplied,
-            latest.ExemptSupplyOutsideUK,
-            latest.ExemptSupplyEII,
+            df.InflatedLevelisationFund,
+            df.TotalElectricitySupplied,
+            df.ExemptSupplyOutsideUK,
+            df.ExemptSupplyEII,
         )
 
         if not revenue:
-            revenue = latest.InflatedLevelisationFund * scaling_factor
+            revenue = df.InflatedLevelisationFund * scaling_factor
         else:
             revenue *= scaling_factor
 
@@ -1375,13 +1527,11 @@ ExemptSupplyEII, ChargeRestrictionPeriod2_start, ChargeRestrictionPeriod2_end fi
             gas_fixed_rate=0,
             general_taxation=0,
             revenue=revenue,
-            ChargeRestrictionPeriod1=latest.ChargeRestrictionPeriod1,
-            ChargeRestrictionPeriod2=latest.ChargeRestrictionPeriod2,
-            LookupPeriod=latest.LookupPeriod,
-            InflatedLevelisationFund=latest.InflatedLevelisationFund,
-            TotalElectricitySupplied=latest.TotalElectricitySupplied,
-            ExemptSupplyOutsideUK=latest.ExemptSupplyOutsideUK,
-            ExemptSupplyEII=latest.ExemptSupplyEII,
+            LookupPeriod=df.LookupPeriod,
+            InflatedLevelisationFund=df.InflatedLevelisationFund,
+            TotalElectricitySupplied=df.TotalElectricitySupplied,
+            ExemptSupplyOutsideUK=df.ExemptSupplyOutsideUK,
+            ExemptSupplyEII=df.ExemptSupplyEII,
         )
 
     @staticmethod

--- a/asf_levies_model/tariffs.py
+++ b/asf_levies_model/tariffs.py
@@ -196,11 +196,11 @@ use the calculate_nil_consumption method.
 
     def __str__(self):
         """String representation of tariff name."""
-        return f"{self.name}"
+        return f'{self.name}, price cap period= "{repr(self.price_cap_period)}"'
 
     def __repr__(self):
         """Representation of tariff name and fuel."""
-        return f'{type(self).__name__}(name="{self.name}", fuel="{self.fuel}")'
+        return f'{type(self).__name__}(name="{self.name}", fuel="{self.fuel}", price cap period= "{repr(self.price_cap_period)}")'
 
 
 class ElectricityStandardCredit(Tariff):

--- a/asf_levies_model/tariffs.py
+++ b/asf_levies_model/tariffs.py
@@ -1,4 +1,7 @@
 import pandas as pd
+from typing import Union
+
+from asf_levies_model.utils.utils import PriceCapPeriod
 
 
 class Tariff:
@@ -35,6 +38,7 @@ class Tariff:
             ebit: float, earnings before interest and tax (EBIT) allowance.
             hap: float, headroom allowance percentage.
             levelisation: float, levelisation.
+            price_cap_period: Interval, price cap period covered by tariff instance.
     """
 
     def __init__(
@@ -66,6 +70,7 @@ class Tariff:
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         """Initializes the instance based on provided tariff parameters.
 
@@ -97,6 +102,7 @@ class Tariff:
             ebit: float, earnings before interest and tax (EBIT) allowance.
             hap: float, headroom allowance percentage.
             levelisation: float, levelisation.
+            price_cap_period: Interval, price cap period covered by tariff instance.
         """
         self.name = name
         self.short_name = short_name
@@ -125,6 +131,7 @@ class Tariff:
         self.ebit = ebit
         self.hap = hap
         self.levelisation = levelisation
+        self.price_cap_period = price_cap_period
 
     def calculate_nil_consumption(self) -> float:
         """Calculate value for nil consumption tariff component."""
@@ -234,6 +241,7 @@ class ElectricityStandardCredit(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(ElectricityStandardCredit, self).__init__(
             name,
@@ -263,6 +271,7 @@ class ElectricityStandardCredit(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -271,6 +280,7 @@ class ElectricityStandardCredit(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 2.7,
+        price_cap: str = "LATEST",
     ) -> "ElectricityStandardCredit":
         """Create ElectricityStandardCredit tariff instance from dataframe input.
 
@@ -283,56 +293,98 @@ class ElectricityStandardCredit(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap: str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="Standard Credit. Electricity Single-Rate Metering Arrangement",
             short_name="Electricity Standard Credit",
             fuel="electricity",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
             levelisation_nil=None,
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
             levelisation=None,
+            price_cap_period=price_cap_date,
         )
 
 
@@ -374,6 +426,7 @@ class GasStandardCredit(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(GasStandardCredit, self).__init__(
             name,
@@ -403,6 +456,7 @@ class GasStandardCredit(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -411,6 +465,7 @@ class GasStandardCredit(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 11.5,
+        price_cap: str = "LATEST",
     ) -> "GasStandardCredit":
         """Create GasStandardCredit tariff instance from dataframe input.
 
@@ -423,56 +478,98 @@ class GasStandardCredit(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap: str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="Standard Credit. Gas",
             short_name="Gas Standard Credit",
             fuel="gas",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
             levelisation_nil=None,
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
             levelisation=None,
+            price_cap_period=price_cap_date,
         )
 
 
@@ -514,6 +611,7 @@ class ElectricityOtherPayment(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(ElectricityOtherPayment, self).__init__(
             name,
@@ -543,6 +641,7 @@ class ElectricityOtherPayment(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -551,6 +650,7 @@ class ElectricityOtherPayment(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 2.7,
+        price_cap: str = "LATEST",
     ) -> "ElectricityOtherPayment":
         """Create ElectricityOtherPayment tariff instance from dataframe input.
 
@@ -563,56 +663,98 @@ class ElectricityOtherPayment(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap: str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="Other Payment Method. Electricity Single-Rate Metering Arrangement",
             short_name="Electricity Other Payment",
             fuel="electricity",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
-            levelisation_nil=nil_latest["Levelisation "],
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
-            levelisation=typical_latest["Levelisation "],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
+            levelisation_nil=nil_df["Levelisation "],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
+            levelisation=typical_df["Levelisation "],
+            price_cap_period=price_cap_date,
         )
 
 
@@ -654,6 +796,7 @@ class GasOtherPayment(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(GasOtherPayment, self).__init__(
             name,
@@ -683,6 +826,7 @@ class GasOtherPayment(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -691,6 +835,7 @@ class GasOtherPayment(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 11.5,
+        price_cap: str = "LATEST",
     ) -> "GasOtherPayment":
         """Create GasOtherPayment tariff instance from dataframe input.
 
@@ -703,56 +848,98 @@ class GasOtherPayment(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap:str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="Other Payment Method. Gas",
             short_name="Gas Other Payment",
             fuel="gas",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
-            levelisation_nil=nil_latest["Levelisation "],
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
-            levelisation=typical_latest["Levelisation "],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
+            levelisation_nil=nil_df["Levelisation "],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
+            levelisation=typical_df["Levelisation "],
+            price_cap_period=price_cap_date,
         )
 
 
@@ -794,6 +981,7 @@ class ElectricityPPM(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(ElectricityPPM, self).__init__(
             name,
@@ -823,6 +1011,7 @@ class ElectricityPPM(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -831,6 +1020,7 @@ class ElectricityPPM(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 2.7,
+        price_cap: str = "LATEST",
     ) -> "ElectricityPPM":
         """Create ElectricityPPM tariff instance from dataframe input.
 
@@ -843,56 +1033,98 @@ class ElectricityPPM(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap:str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="PPM. Electricity Single-Rate Metering Arrangement",
             short_name="Electricity PPM",
             fuel="electricity",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
-            levelisation_nil=nil_latest["Levelisation "],
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
-            levelisation=typical_latest["Levelisation "],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
+            levelisation_nil=nil_df["Levelisation "],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
+            levelisation=typical_df["Levelisation "],
+            price_cap_period=price_cap_date,
         )
 
 
@@ -934,6 +1166,7 @@ class GasPPM(Tariff):
         ebit: float,
         hap: float,
         levelisation: float,
+        price_cap_period: Union[pd.Interval, "PriceCapPeriod"],
     ) -> None:
         super(GasPPM, self).__init__(
             name,
@@ -963,6 +1196,7 @@ class GasPPM(Tariff):
             ebit,
             hap,
             levelisation,
+            price_cap_period,
         )
 
     @classmethod
@@ -971,6 +1205,7 @@ class GasPPM(Tariff):
         nil_df: pd.DataFrame,
         typical_df: pd.DataFrame,
         typical_consumption: float = 11.5,
+        price_cap: str = "LATEST",
     ) -> "GasPPM":
         """Create GasPPM tariff instance from dataframe input.
 
@@ -983,54 +1218,96 @@ class GasPPM(Tariff):
             nil_df: a dataframe with values for nil consumption.
             typical_df: a dataframe with values for typical consumption.
             typical_consumption: float, the typical consumption value used in `typical_df`.
+            price_cap:str, the price cap period to return, default: LATEST.
         """
         # Get latest values from nil and typical dfs.
-        nil_latest = (
-            nil_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Nil consumption")
-            .loc[:, "value"]
-        )
-        typical_latest = (
-            typical_df.loc[
-                lambda df: df["28AD_Charge_Restriction_Period_start"]
-                == df["28AD_Charge_Restriction_Period_start"].max()
-            ]
-            .set_index("Typical consumption")
-            .loc[:, "value"]
-        )
+        if price_cap == "LATEST":
+            nil_price_cap = nil_df.index.max()[1]
+            nil_df = (
+                nil_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(nil_price_cap) else False
+                    )
+                ]
+                .set_index("Nil consumption")
+                .loc[:, "value"]
+            )
+
+            typical_price_cap = typical_df.index.max()[1]
+            typical_df = (
+                typical_df.loc[
+                    lambda df: df.index.map(
+                        lambda x: True if x[1].overlaps(typical_price_cap) else False
+                    )
+                ]
+                .set_index("Typical consumption")
+                .loc[:, "value"]
+            )
+
+            assert nil_price_cap == typical_price_cap
+            price_cap_date = PriceCapPeriod(
+                left=nil_price_cap.left, right=nil_price_cap.right, closed="both"
+            )
+        else:
+            # Otherwise assume you've got a provided date
+            price_cap_date = pd.to_datetime(price_cap)
+            nil_mask = nil_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+            typical_mask = typical_df.index.map(
+                lambda x: True if price_cap_date in x[1] else False
+            ).to_numpy()
+
+            price_cap_date = nil_df.index[
+                nil_df.index.map(lambda x: True if price_cap_date in x[1] else False)
+            ].unique()[0][1]
+
+            price_cap_date = PriceCapPeriod(
+                left=price_cap_date.left, right=price_cap_date.right, closed="both"
+            )
+
+            if (nil_mask.sum() == 0) | (typical_mask.sum() == 0):
+                raise IndexError(f"Price cap data {price_cap} not found in index.")
+            else:
+                nil_df = (
+                    nil_df.loc[nil_mask].set_index("Nil consumption").loc[:, "value"]
+                )
+                typical_df = (
+                    typical_df.loc[typical_mask]
+                    .set_index("Typical consumption")
+                    .loc[:, "value"]
+                )
 
         # Get unit costs per MWh
-        typical_latest = (typical_latest - nil_latest.fillna(0)) / typical_consumption
+        typical_df = (typical_df - nil_df.fillna(0)) / typical_consumption
 
         return cls(
             name="PPM. Gas",
             short_name="Gas PPM",
             fuel="gas",
-            df_nil=nil_latest["DF"],
-            cm_nil=nil_latest["CM"],
-            aa_nil=nil_latest["AA"],
-            pc_nil=nil_latest["PC"],
-            nc_nil=nil_latest["NC"],
-            oc_nil=nil_latest["OC"],
-            smncc_nil=nil_latest["SMNCC"],
-            paac_nil=nil_latest["PAAC"],
-            pap_nil=nil_latest["PAP"],
-            ebit_nil=nil_latest["EBIT"],
-            hap_nil=nil_latest["HAP"],
-            levelisation_nil=nil_latest["Levelisation "],
-            df=typical_latest["DF"],
-            cm=typical_latest["CM"],
-            aa=typical_latest["AA"],
-            pc=typical_latest["PC"],
-            nc=typical_latest["NC"],
-            oc=typical_latest["OC"],
-            smncc=typical_latest["SMNCC"],
-            paac=typical_latest["PAAC"],
-            pap=typical_latest["PAP"],
-            ebit=typical_latest["EBIT"],
-            hap=typical_latest["HAP"],
-            levelisation=typical_latest["Levelisation "],
+            df_nil=nil_df["DF"],
+            cm_nil=nil_df["CM"],
+            aa_nil=nil_df["AA"],
+            pc_nil=nil_df["PC"],
+            nc_nil=nil_df["NC"],
+            oc_nil=nil_df["OC"],
+            smncc_nil=nil_df["SMNCC"],
+            paac_nil=nil_df["PAAC"],
+            pap_nil=nil_df["PAP"],
+            ebit_nil=nil_df["EBIT"],
+            hap_nil=nil_df["HAP"],
+            levelisation_nil=nil_df["Levelisation "],
+            df=typical_df["DF"],
+            cm=typical_df["CM"],
+            aa=typical_df["AA"],
+            pc=typical_df["PC"],
+            nc=typical_df["NC"],
+            oc=typical_df["OC"],
+            smncc=typical_df["SMNCC"],
+            paac=typical_df["PAAC"],
+            pap=typical_df["PAP"],
+            ebit=typical_df["EBIT"],
+            hap=typical_df["HAP"],
+            levelisation=typical_df["Levelisation "],
+            price_cap_period=price_cap_date,
         )

--- a/asf_levies_model/utils/utils.py
+++ b/asf_levies_model/utils/utils.py
@@ -1,4 +1,15 @@
+import pandas as pd
 from typing import Callable
+
+
+class PriceCapPeriod(pd.Interval):
+    """Subclassing the pandas interval object so it outputs a nice repr."""
+
+    def __init__(self, left, right, closed):
+        super().__init__(left, right, closed)
+
+    def __repr__(self):
+        return f"{self.left.strftime('%d/%m/%Y')} - {self.right.strftime('%d/%m/%Y')}"
 
 
 def _generate_docstring(inherited: str, new_params: list) -> Callable:


### PR DESCRIPTION
---

# Description

This is a fairly complicated PR. The main objective is to enable time by adding price cap period information to the levies and tariff objects. The default behaviour is the same as previously and returns the most recent price cap data for the input data provided, however there is a new argument in the `.from_dataframe()` constructor of all levy and tariff objects that allows you to provide a date and return historic data. To do this, I have:
1. Manually created a 28AD multiindex based on the price cap periods in annex 4.
2. Applied the index to all data getters for levies and tariffs. This involved removing some redundant code.
    - NB tariffs are set up slightly differently. There is no historic data as in levies, so price caps start in Jan 2019 and only run to the present price cap. I had to rewrite the process tariff functions more extensively as a result.
3. Updated levy class to include price_cap attribute and to print price cap in repr and str.
4. Rewrote specific levy `.from_dataframe()` constructors to allow for price caps to be specified.
5. Updated tariff class to include price_cap attribute and to print price cap in repr and str.
6. Rewrote specific tariff `.from_dataframe()` constructors to allow for price caps to be specified.

Note, I initially considered an object that captured a time series, but this felt like too big a leap. However using these updated classes you could now create a collection of levy objects capturing a series of price caps of interest.

# Instructions for Reviewer

This needs a general review to ensure that the revised process_data_ functions return data correctly, and that this flows through to correctly instantiated levy and tariff objects.

Please pay special attention to the data getters and the updated levy and tariff objects.

# Checklist:

- [ x ] I have refactored my code out from `notebooks/`
- [ x ] I have checked the code runs
- [ x ] I have tested the code
- [  x ] I have run `pre-commit` and addressed any issues not automatically fixed
- [  x ] I have merged any new changes from `dev`
- [  x  ] I have documented the code
  - [ x ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ x ] I have explained this PR above
- [ x ] I have requested a code review
