### PR TITLE
Add rising block type discount method

### DIFF
--- a/asf_levies_model/consumers.py
+++ b/asf_levies_model/consumers.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import copy
-from typing import Optional
+from typing import Optional, Dict, Union
 
 from asf_levies_model.tariffs import Tariff
 
@@ -206,7 +206,7 @@ class Consumer:
     def apply_social_support_adjustment(
         self,
         adjustment_fuel: str,
-        adjustment_parameter: float,
+        adjustment_parameter: Union[float, Dict],
         adjustment_mode: str,
         inplace: bool = False,
     ) -> "Consumer | None":
@@ -216,13 +216,15 @@ class Consumer:
         ----------
         adjustment_fuel : str
             Fuel bill to be adjusted, accepted strings are "electricity" and "gas".
-        adjustment_parameter : float
+        adjustment_parameter : Union[float, Dict]
             Value with which to adjust the fuel bill depending on adjustment mode. If adjustment mode is:
             (a) flat adjustment: Value (£) to be added to the total bill.
             (b) percentage discount: Percentage (%) of subtotal bill to be subtracted.
             (c) unit discount: Value (£/MWh) to be multiplied by fuel consumption, and product subtracted from the total bill.
+            (d) rising block: Applies a varying unit discount for specified blocks of consumption units. Dictionary with keys "thresholds" and "discounts".
+                Value of "thresholds" and "discounts" keys must be provided as List[float].
         adjustment_mode : str
-            Acceptable strings are "flat adjustment", "percentage discount" and "unit discount".
+            Acceptable strings are "flat adjustment", "percentage discount", "unit discount" and "rising block".
         inplace : bool
             Make fuel bill change in place (True) or return copy (False), by default False.
 
@@ -264,9 +266,39 @@ class Consumer:
             adjusted_bill = bill[adjustment_fuel] - (
                 consumption[adjustment_fuel] * adjustment_parameter
             )
+        elif adjustment_mode == "rising block":
+
+            thresholds = adjustment_parameter["thresholds"]
+            discounts = adjustment_parameter["discounts"]
+
+            discount_amounts = []
+            for i in range(len(thresholds)):
+
+                # First block
+                if i == 0:
+                    applicable_units = min(consumption[adjustment_fuel], thresholds[i])
+
+                # Subsequent blocks
+                else:
+                    applicable_units = (
+                        min(consumption[adjustment_fuel], thresholds[i])
+                        - thresholds[i - 1]
+                    )
+
+                # Discount for applicable units in this block
+                if applicable_units > 0:
+                    discount_amounts.append(applicable_units * discounts[i])
+
+                # Stop loop if consumption is below current threshold
+                if consumption[adjustment_fuel] <= thresholds[i]:
+                    break
+
+            # Apply total discount to bill
+            adjusted_bill = bill[adjustment_fuel] - sum(discount_amounts)
+
         else:
             raise ValueError(
-                "Please provide an adjustment mode from the following: flat adjustment, percentage_discount, unit discount"
+                "Please provide an adjustment mode from the following: flat adjustment, percentage_discount, unit discount, rising block."
             )
 
         # Update attribute

--- a/asf_levies_model/notebooks/consumer_class_example.py
+++ b/asf_levies_model/notebooks/consumer_class_example.py
@@ -379,6 +379,131 @@ typical_eligible.electricity_bill, typical_eligible.gas_bill
 )
 
 # %% [markdown]
+# **Adjustment mode: Rising block discount**
+# * This mode calculates discount based on varying unit discount rates for specific blocks of consumption units, and subtracts that discount from the total fuel bill.
+
+# %%
+# Create a 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    unmetered_fuel_spend=0,
+    scheme_eligible=True,
+)
+
+# %% [markdown]
+# Example discount structure:
+# - For units of electricity below 1 MWh, apply a unit discount of 50 £/MWh
+# - For units of electricity between 1-2 MWh, apply a unit discount of 30 £/MWh
+# - For units of electricity between 2-3 MWh, apply a unit discount of 10 £/MWh
+# - No discount applied for units of electricity above 3 MWh
+#
+# Note: All consumption thresholds are annual.
+
+# %%
+discount_structure = {
+    "thresholds": [1, 2, 3],
+    "discounts": [50, 30, 10],
+}
+
+# %%
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# %% [markdown]
+# With consumption = 2.7, we expect the following discount:
+# - (1 - 0) * 50 = 50
+# - (2 - 1) * 30 = 30
+# - (2.7 - 2) * 10 = 7
+# - Total = £87 discount
+
+# %%
+# Verify discount applied
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %% [markdown]
+# Applying an additional discount structure
+
+# %%
+discount_structure_additional = {
+    "thresholds": [1, 2, 3],
+    "discounts": [30, 20, 10],
+}
+
+# %%
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure_additional,
+        adjustment_mode="rising block",
+    )
+
+# %% [markdown]
+# With consumption = 2.7, we expect the following discount:
+# - (1 - 0) * 30 = 30
+# - (2 - 1) * 20 = 20
+# - (2.7 - 2) * 10 = 7
+# - Total = £57 + £87 discount from first discount structure = £144
+
+# %%
+# Verify discount applied
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %% [markdown]
+# Checking that a discount structure with only 1 threshold works.
+
+# %%
+# Create a 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    unmetered_fuel_spend=0,
+    scheme_eligible=True,
+)
+
+# %%
+discount_structure = {
+    "thresholds": [2],
+    "discounts": [50],
+}
+
+# %% [markdown]
+# This translates to:
+# - First 2 MWh of consumption gets a discount of 50 £/MWh
+# - Over 2 MWh of consumption does not get a discount
+# - Total discount for 2.7 MWh electricity = 2 * 50 = £100
+
+# %%
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# %%
+# Verify discount applied
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %% [markdown]
 # **Applying different adjustment modes**
 
 # %%
@@ -640,6 +765,189 @@ typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
 (typical_eligible.electricity_consumption * 50) + (
     typical_eligible.electricity_subtotal_bill * 0.1
 )
+
+# %% [markdown]
+# **Combination 4: Percentage discount + rising block unit discount**
+
+# %%
+# Create a scheme eligible 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    scheme_eligible=True,
+)
+
+# Evaluate a percentage discount support rate of 10% to electricity bills
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=10,
+        adjustment_mode="percentage discount",
+    )
+
+
+# Evaluate a rising block unit discount
+discount_structure = {
+    "thresholds": [1, 2, 3],
+    "discounts": [50, 30, 10],
+}
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# %%
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %%
+(typical_eligible.electricity_subtotal_bill * 0.1) + (50 + 30 + 7)
+
+# %% [markdown]
+# Order of operations doesn't matter.
+
+# %%
+# Create a scheme eligible 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    scheme_eligible=True,
+)
+
+# Evaluate a rising block unit discount
+discount_structure = {
+    "thresholds": [1, 2, 3],
+    "discounts": [50, 30, 10],
+}
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# Evaluate a percentage discount support rate of 10% to electricity bills
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=10,
+        adjustment_mode="percentage discount",
+    )
+
+# %%
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %%
+(typical_eligible.electricity_subtotal_bill * 0.1) + (50 + 30 + 7)
+
+# %% [markdown]
+# **Combination 5: Flat rebate + rising block unit discount**
+
+# %%
+# Create a scheme eligible 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    scheme_eligible=True,
+)
+
+# Apply another £150 discount to electricity bills
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=-150,
+        adjustment_mode="flat adjustment",
+    )
+
+
+# Evaluate a rising block unit discount
+discount_structure = {
+    "thresholds": [1, 2, 3],
+    "discounts": [50, 30, 10],
+}
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# %%
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %%
+(150) + (50 + 30 + 7)
+
+# %% [markdown]
+# Order of operations also doesn't matter here.
+
+# %%
+# Create a scheme eligible 'typical' consumer
+typical_eligible = Consumer(
+    name="Typical",
+    archetype=None,
+    net_annual_income=35_464,
+    net_income_decile=5,
+    main_heating_fuel="gas",
+    gas_consumption=11.5,
+    electricity_consumption=2.7,
+    gas_tariff=gas_tariff,
+    electricity_tariff=electricity_tariff,
+    scheme_eligible=True,
+)
+
+
+# Evaluate a rising block unit discount
+discount_structure = {
+    "thresholds": [1, 2, 3],
+    "discounts": [50, 30, 10],
+}
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=discount_structure,
+        adjustment_mode="rising block",
+    )
+
+# Apply another £150 discount to electricity bills
+if typical_eligible.scheme_eligible:
+    typical_eligible = typical_eligible.apply_social_support_adjustment(
+        adjustment_fuel="electricity",
+        adjustment_parameter=-150,
+        adjustment_mode="flat adjustment",
+    )
+
+# %%
+typical_eligible.electricity_subtotal_bill - typical_eligible.electricity_bill
+
+# %%
+(150) + (50 + 30 + 7)
+
+# %% [markdown]
+# **Combination 6: Unit discount + rising block unit discount**
+# - This combination would not be applied as it is two forms of the same type of discount.
 
 # %% [markdown]
 # **Other calculated properties of a Consumer**


### PR DESCRIPTION
---

# Description

This code introduces "rising block" discount as a new social support adjustment mode to the `Consumer.apply_social_support_adjustment()` method. This new adjustment mode is enabled with the following arguments:
- `adjustment_mode = "rising block"`
- `adjustment_parameter = {"thresholds" = [Threshold1, Threshold2, ...], "discounts" = [Discount1, Discount2, ...]}`

This mode applies a unit discount for specified blocks of consumption units.

# Instructions for Reviewer

Please review the new "rising block" conditional block in the `.apply_social_support_adjustment()` method and its accompanying documentation, checking for any errors, inconsistencies or opportunities for improvement. You can also test its functionality in new demo sections in the `consumers_example.py` notebook. 

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
